### PR TITLE
add some ast_dump tests

### DIFF
--- a/scripts.yml
+++ b/scripts.yml
@@ -22,3 +22,9 @@ scripts:
 
     gen_ast:
         cmd: cd run-tests && ls -1 *.py | xargs -n1 python3 tools/dump-ast.py
+
+    test:
+        cmd: deno test
+        allow:
+            - read
+            - run

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -36,13 +36,14 @@ function _format(node: nodeType | nodeType[], level = 0, indent: string | null =
         }
         return [`[${prefix}${node.map((x) => _format(x, level, indent)[0]).join(sep)}]`, false];
     } else {
+        /** @todo most of this is a hack while we don't have python types */
         let ret: string;
         if (node === true) {
             ret = "True";
         } else if (node === false) {
             ret = "False";
         } else if (typeof node === "number") {
-            if (node > 0 && node < 0.0001) {
+            if ((node > 0 && node < 0.0001) || (node < 0 && node > -0.0001)) {
                 ret = node.toExponential().replace(/(e[-+])([1-9])$/, "$10$2");
             } else {
                 ret = node.toString();
@@ -54,7 +55,7 @@ function _format(node: nodeType | nodeType[], level = 0, indent: string | null =
             ret = node;
         } else if (node instanceof Number) {
             /**Brython trick for floats */
-            if (node > 0 && node < 0.0001) {
+            if ((node > 0 && node < 0.0001) || (node < 0 && node > -0.0001)) {
                 ret = node.toExponential().replace(/(e[-+])([1-9])$/, "$10$2");
             } else {
                 ret = node.toString();

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -1,6 +1,6 @@
 import { AST } from "./astnodes.ts";
 
-type nodeType = AST | boolean | string | number;
+type nodeType = AST | boolean | string | number | bigint | Number;
 
 function _format(node: nodeType | nodeType[], level = 0, indent: string | null = null): [string, boolean] {
     let prefix: string, sep: string;
@@ -42,10 +42,24 @@ function _format(node: nodeType | nodeType[], level = 0, indent: string | null =
         } else if (node === false) {
             ret = "False";
         } else if (typeof node === "number") {
-            ret = "" + node;
+            if (node > 0 && node < 0.0001) {
+                ret = node.toExponential().replace(/(e[-+])([1-9])$/, "$10$2");
+            } else {
+                ret = node.toString();
+            }
+        } else if (typeof node === "bigint") {
+            ret = node.toString();
         } else if (node === "None") {
             /** @todo temporary - since we don't have pyNone */
             ret = node;
+        } else if (node instanceof Number) {
+            /**Brython trick for floats */
+            if (node > 0 && node < 0.0001) {
+                ret = node.toExponential().replace(/(e[-+])([1-9])$/, "$10$2");
+            } else {
+                ret = node.toString();
+                ret = ret.includes(".") ? ret : ret + ".0";
+            }
         } else {
             let quote = "'";
             if (node.includes("'") && !node.includes('"')) {

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -43,6 +43,9 @@ function _format(node: nodeType | nodeType[], level = 0, indent: string | null =
             ret = "False";
         } else if (typeof node === "number") {
             ret = "" + node;
+        } else if (node === "None") {
+            /** @todo temporary - since we don't have pyNone */
+            ret = node;
         } else {
             let quote = "'";
             if (node.includes("'") && !node.includes('"')) {

--- a/src/ast/astnodes.ts
+++ b/src/ast/astnodes.ts
@@ -754,9 +754,9 @@ YieldFrom.prototype.tp$name = "YieldFrom";
 
 export class Compare extends expr {
     left: expr;
-    ops: number[];
+    ops: cmpop[];
     comparators: expr[];
-    constructor(left: expr, ops: number[], comparators: expr[], ...attrs: exprAttrs) {
+    constructor(left: expr, ops: cmpop[], comparators: expr[], ...attrs: exprAttrs) {
         super(...attrs);
         this.left = left;
         this.ops = ops;
@@ -997,11 +997,27 @@ export class arg extends AST {
     arg: identifier;
     annotation: expr | null;
     type_comment: string | null;
-    constructor(arg: identifier, annotation: expr | null, type_comment: string | null) {
+    lineno: number;
+    col_offset: number;
+    end_lineno: number | null;
+    end_col_offset: number | null;
+    constructor(
+        arg: identifier,
+        annotation: expr | null,
+        type_comment: string | null,
+        lineno: number,
+        col_offset: number,
+        end_lineno: number | null,
+        end_col_offset: number | null
+    ) {
         super();
         this.arg = arg;
         this.annotation = annotation;
         this.type_comment = type_comment;
+        this.lineno = lineno;
+        this.col_offset = col_offset;
+        this.end_lineno = end_lineno;
+        this.end_col_offset = end_col_offset;
     }
 }
 arg.prototype._fields = ["arg", "annotation", "type_comment"];
@@ -1011,10 +1027,25 @@ arg.prototype.tp$name = "arg";
 export class keyword extends AST {
     arg: identifier | null;
     value: expr;
-    constructor(arg: identifier | null, value: expr) {
+    lineno: number;
+    col_offset: number;
+    end_lineno: number | null;
+    end_col_offset: number | null;
+    constructor(
+        arg: identifier | null,
+        value: expr,
+        lineno: number,
+        col_offset: number,
+        end_lineno: number | null,
+        end_col_offset: number | null
+    ) {
         super();
         this.arg = arg;
         this.value = value;
+        this.lineno = lineno;
+        this.col_offset = col_offset;
+        this.end_lineno = end_lineno;
+        this.end_col_offset = end_col_offset;
     }
 }
 keyword.prototype._fields = ["arg", "value"];

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -41,7 +41,8 @@ async function convertToTs(content: string): Promise<string> {
         .replace(/^(\s*)([A-Za-z_]+)/gm, (m, m1, m2) => {
             if (m2 === "null" || m2 === "True" || m2 === "False") {
                 return m1 + m2.toLowerCase();
-            } else if (m2 === "arguments") {
+            }
+            if (m2 === "arguments") {
                 m2 += "_";
             }
             return m1 + "new astnodes." + m2;

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -37,7 +37,7 @@ async function getPyAstDump(content: string, indent: number | null = 4, attrs = 
 async function convertToTs(content: string): Promise<string> {
     let py_ast_dump = await getPyAstDump(content, 4, true, true);
     py_ast_dump = py_ast_dump
-        .replace(/^(\s+)([a-z_]+=)/gm, (m, m1, m2) => m1 + " ".repeat(m2.length))
+        .replace(/([(\s]+)([a-z_]+=)/gm, (m, m1, m2) => m1 + " ".repeat(m2.length))
         .replace(/^(\s*)([A-Za-z_]+)/gm, (m, m1, m2) => {
             if (m2 === "null" || m2 === "True" || m2 === "False") {
                 return m1 + m2.toLowerCase();
@@ -45,7 +45,9 @@ async function convertToTs(content: string): Promise<string> {
                 m2 += "_";
             }
             return m1 + "new astnodes." + m2;
-        });
+        })
+        .replace(/([0-9]{16,})/g, (m, m1) => m1 + "n");
+    // use bigint
     return py_ast_dump;
 }
 
@@ -73,7 +75,7 @@ for await (const dirEntry of Deno.readDir("run-tests/")) {
     files.push(dirEntry.name);
 }
 files.sort();
-const skip = new Set([62, 85, 86, 108].map((x) => `t${x.toString().padStart(3, "0")}.py`));
+const skip = new Set();
 
 for (const test of files) {
     if (skip.has(test)) {

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -1,0 +1,231 @@
+import * as astnodes from "../src/ast/astnodes.ts";
+import { dump } from "../src/ast/ast.ts";
+import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
+
+/** Simple name and function, compact form, but not configurable */
+async function getPyAstDump(content: string, indent: number | null = 4, attrs = false): Promise<string> {
+    const cmd = Deno.run({
+        cmd: [
+            "python3",
+            "tests/ast_dumper_helper.py",
+            content,
+            `--indent=${indent === null ? -1 : indent}`,
+            attrs ? "--attrs=1" : "--attrs=0",
+        ],
+        stdout: "piped",
+        stderr: "piped",
+    });
+
+    const output = await cmd.output(); // "piped" must be set
+    const outStr = new TextDecoder().decode(output);
+
+    const error = await cmd.stderrOutput();
+    const errorStr = new TextDecoder().decode(error);
+    cmd.close(); // Don't forget to close it
+
+    if (errorStr) {
+        throw new Error(errorStr);
+    }
+
+    return outStr;
+}
+
+/** helper function to generate an ast tree that can be converted in typescript - you'll need to add in missing null values */
+async function convertToTs(content: string): Promise<void> {
+    let py_ast_dump = await getPyAstDump(content, 4, true);
+    py_ast_dump = py_ast_dump
+        .replace(/^(\s+)([a-z_]+=)/gm, (m, m1, m2) => m1 + " ".repeat(m2.length))
+        .replace(/^(\s*)([A-Za-z_]+)/gm, (m, m1, m2) => m1 + "new astnodes." + m2);
+    console.log(py_ast_dump);
+}
+
+async function doTest(source: string, mod: astnodes.Module) {
+    for (let indent of [null, 0, 2, 4]) {
+        const py_ast_dump = await getPyAstDump(source, indent);
+        assertEquals(py_ast_dump, dump(mod, indent) + "\n");
+    }
+}
+
+Deno.test("#1: t001.py print('hello world')", async () => {
+    const mod = new astnodes.Module(
+        [
+            new astnodes.Expr(
+                new astnodes.Call(
+                    new astnodes.Name("print", new astnodes.Load(), 1, 0, 1, 5),
+                    [new astnodes.Constant("hello world", null, 1, 6, 1, 19)],
+                    [],
+                    1,
+                    0,
+                    1,
+                    20
+                ),
+                1,
+                0,
+                1,
+                20
+            ),
+        ],
+        []
+    );
+    await doTest("print('hello world')", mod);
+});
+
+Deno.test("#2: t002py a = 3", async () => {
+    const mod = new astnodes.Module(
+        [
+            new astnodes.Assign(
+                [new astnodes.Name("a", new astnodes.Store(), 1, 0, 1, 1)],
+                new astnodes.Constant(3, null, 1, 4, 1, 5),
+                null,
+                1,
+                0,
+                1,
+                5
+            ),
+        ],
+        []
+    );
+    await doTest("a = 3", mod);
+});
+
+Deno.test("#3: t003.py 2 + 3", async () => {
+    const mod = new astnodes.Module(
+        [
+            new astnodes.Expr(
+                new astnodes.BinOp(
+                    new astnodes.Constant(2, null, 1, 0, 1, 1),
+                    new astnodes.Add(),
+                    new astnodes.Constant(3, null, 1, 4, 1, 5),
+                    1,
+                    0,
+                    1,
+                    5
+                ),
+                1,
+                0,
+                1,
+                5
+            ),
+        ],
+        []
+    );
+    await doTest("2 + 3", mod);
+});
+
+Deno.test("#4: t014.py def test(x, y): return x + y ", async () => {
+    const mod = new astnodes.Module(
+        [
+            new astnodes.FunctionDef(
+                "test",
+                new astnodes.arguments_(
+                    [],
+                    [new astnodes.arg("x", null, null, 2, 9, 2, 10), new astnodes.arg("y", null, null, 2, 12, 2, 13)],
+                    null,
+                    [],
+                    [],
+                    null,
+                    []
+                ),
+                [
+                    new astnodes.Return(
+                        new astnodes.BinOp(
+                            new astnodes.Name("x", new astnodes.Load(), 3, 11, 3, 12),
+                            new astnodes.Add(),
+                            new astnodes.Name("y", new astnodes.Load(), 3, 15, 3, 16),
+                            3,
+                            11,
+                            3,
+                            16
+                        ),
+                        3,
+                        4,
+                        3,
+                        16
+                    ),
+                ],
+                [],
+                null,
+                null,
+                2,
+                0,
+                3,
+                16
+            ),
+            new astnodes.Assign(
+                [new astnodes.Name("r", new astnodes.Store(), 6, 0, 6, 1)],
+                new astnodes.Call(
+                    new astnodes.Name("test", new astnodes.Load(), 6, 4, 6, 8),
+                    [new astnodes.Constant(3, null, 6, 9, 6, 10), new astnodes.Constant(5, null, 6, 12, 6, 13)],
+                    [],
+                    6,
+                    4,
+                    6,
+                    14
+                ),
+                null,
+                6,
+                0,
+                6,
+                14
+            ),
+        ],
+        []
+    );
+
+    const content = `
+def test(x, y):
+    return x + y
+
+
+r = test(3, 5)
+`;
+
+    await doTest(content, mod);
+});
+
+/**@todo this should really be pyNone */
+Deno.test("#5: t019.py if None is None", async () => {
+    const mod = new astnodes.Module(
+        [
+            new astnodes.If(
+                new astnodes.Compare(
+                    new astnodes.Constant("None", null, 2, 3, 2, 7),
+                    [new astnodes.Is()],
+                    [new astnodes.Constant("None", null, 2, 11, 2, 15)],
+                    2,
+                    3,
+                    2,
+                    15
+                ),
+                [
+                    new astnodes.Expr(
+                        new astnodes.Call(
+                            new astnodes.Name("print", new astnodes.Load(), 3, 4, 3, 9),
+                            [new astnodes.Constant("OK", null, 3, 10, 3, 14)],
+                            [],
+                            3,
+                            4,
+                            3,
+                            15
+                        ),
+                        3,
+                        4,
+                        3,
+                        15
+                    ),
+                ],
+                [],
+                2,
+                0,
+                3,
+                15
+            ),
+        ],
+        []
+    );
+    const content = `
+if None is None:
+    print("OK")
+`;
+    await doTest(content, mod);
+});

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -61,7 +61,7 @@ async function convertFileToTs(fileName: string) {
 }
 
 async function doTest(source: string, mod: astnodes.Module) {
-    for (let indent of [null, 0, 2, 4]) {
+    for (let indent of [null, /* 0, 2,*/ 4]) {
         const py_ast_dump = await getPyAstDump(source, indent);
         assertEquals(py_ast_dump, dump(mod, indent) + "\n");
     }

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -37,7 +37,7 @@ async function getPyAstDump(content: string, indent: number | null = 4, attrs = 
 async function convertToTs(content: string): Promise<string> {
     let py_ast_dump = await getPyAstDump(content, 4, true, true);
     py_ast_dump = py_ast_dump
-        .replace(/([(\s]+)([a-z_]+=)/gm, (m, m1, m2) => m1 + " ".repeat(m2.length))
+        .replace(/^(\s+)([a-z_]+=)/gm, (m, m1, m2) => m1 + " ".repeat(m2.length))
         .replace(/^(\s*)([A-Za-z_]+)/gm, (m, m1, m2) => {
             if (m2 === "null" || m2 === "True" || m2 === "False") {
                 return m1 + m2.toLowerCase();
@@ -47,7 +47,8 @@ async function convertToTs(content: string): Promise<string> {
             }
             return m1 + "new astnodes." + m2;
         })
-        .replace(/([0-9]{16,})/g, (m, m1) => m1 + "n");
+        .replace(/^(\s+\-?[0-9]+\.[0-9]+(?:e[\-0-9]+)?)/gm, (m, m1) => "new Number(" + m1 + ")")
+        .replace(/^(\s+\-?[0-9]{16,})/gm, (m, m1) => m1 + "n");
     // use bigint
     return py_ast_dump;
 }

--- a/tests/ast_dumper_helper.py
+++ b/tests/ast_dumper_helper.py
@@ -23,6 +23,13 @@ class Null:
 null = Null()
 
 
+def clean_val(x):
+    # we're hacking a bit since we don't have pyStr
+    if isinstance(x, str):
+        return repr(x)[1:-1]
+    return x
+
+
 class jsVisitor(ast.NodeTransformer):
     def visit(self, node):
         cls = type(node)
@@ -35,16 +42,17 @@ class jsVisitor(ast.NodeTransformer):
             elif isinstance(old_value, ast.AST):
                 fields.append(self.visit(old_value))
             elif isinstance(old_value, list):
+
                 fields.append(
                     list(
                         map(
-                            lambda x: self.visit(x) if isinstance(x, ast.AST) else x,
+                            lambda x: self.visit(x) if isinstance(x, ast.AST) else clean_val(x),
                             old_value,
                         )
                     )
                 )
             else:
-                fields.append(old_value)
+                fields.append(clean_val(old_value))
         attrs = list(map(lambda attr: [attr, getattr(node, attr)], node._attributes))
         try:
             return cls(*fields, **dict(attrs))

--- a/tests/ast_dumper_helper.py
+++ b/tests/ast_dumper_helper.py
@@ -6,7 +6,13 @@ parser = argparse.ArgumentParser(description="Dump AST from file to file")
 parser.add_argument("content", type=str, help="source to be parsed")
 parser.add_argument("--indent", type=int, default=None, required=False, help="indent")
 parser.add_argument("--attrs", type=int, default=0, required=False, help="show attrs")
-parser.add_argument("--js", type=int, default=0, required=False, help="are we generating js sanitized version")
+parser.add_argument(
+    "--js",
+    type=int,
+    default=0,
+    required=False,
+    help="are we generating js sanitized version",
+)
 
 args = parser.parse_args()
 
@@ -63,4 +69,4 @@ class jsVisitor(ast.NodeTransformer):
 if args.js:
     parsed = jsVisitor().generic_visit(parsed)
 
-print(ast.dump(parsed, include_attributes=args.attrs, indent=indent))
+print(ast.dump(parsed, annotate_fields=not args.js, include_attributes=args.attrs, indent=indent))

--- a/tests/ast_dumper_helper.py
+++ b/tests/ast_dumper_helper.py
@@ -6,7 +6,7 @@ parser = argparse.ArgumentParser(description="Dump AST from file to file")
 parser.add_argument("content", type=str, help="source to be parsed")
 parser.add_argument("--indent", type=int, default=None, required=False, help="indent")
 parser.add_argument("--attrs", type=int, default=0, required=False, help="show attrs")
-parser.add_argument("--js", type=int, default=0, required=False, help="show attrs")
+parser.add_argument("--js", type=int, default=0, required=False, help="are we generating js sanitized version")
 
 args = parser.parse_args()
 
@@ -14,7 +14,7 @@ parsed = ast.parse(args.content)
 indent = args.indent if args.indent != -1 else None
 
 
-# We need null values to fil empty fields
+# We need null values to fill empty fields
 class Null:
     def __repr__(self):
         return "null"

--- a/tests/ast_dumper_helper.py
+++ b/tests/ast_dumper_helper.py
@@ -6,9 +6,53 @@ parser = argparse.ArgumentParser(description="Dump AST from file to file")
 parser.add_argument("content", type=str, help="source to be parsed")
 parser.add_argument("--indent", type=int, default=None, required=False, help="indent")
 parser.add_argument("--attrs", type=int, default=0, required=False, help="show attrs")
+parser.add_argument("--js", type=int, default=0, required=False, help="show attrs")
 
 args = parser.parse_args()
 
 parsed = ast.parse(args.content)
 indent = args.indent if args.indent != -1 else None
+
+
+# We need null values to fil empty fields
+class Null:
+    def __repr__(self):
+        return "null"
+
+
+null = Null()
+
+
+class jsVisitor(ast.NodeTransformer):
+    def visit(self, node):
+        cls = type(node)
+        fields = []
+        for field, old_value in ast.iter_fields(node):
+            if old_value is None and getattr(cls, field, ...) is None:
+                fields.append(null)
+            elif old_value is None:
+                fields.append("None")
+            elif isinstance(old_value, ast.AST):
+                fields.append(self.visit(old_value))
+            elif isinstance(old_value, list):
+                fields.append(
+                    list(
+                        map(
+                            lambda x: self.visit(x) if isinstance(x, ast.AST) else x,
+                            old_value,
+                        )
+                    )
+                )
+            else:
+                fields.append(old_value)
+        attrs = list(map(lambda attr: [attr, getattr(node, attr)], node._attributes))
+        try:
+            return cls(*fields, **dict(attrs))
+        except Exception:
+            raise
+
+
+if args.js:
+    parsed = jsVisitor().generic_visit(parsed)
+
 print(ast.dump(parsed, include_attributes=args.attrs, indent=indent))

--- a/tests/ast_dumper_helper.py
+++ b/tests/ast_dumper_helper.py
@@ -1,0 +1,14 @@
+import ast
+import argparse
+
+parser = argparse.ArgumentParser(description="Dump AST from file to file")
+
+parser.add_argument("content", type=str, help="source to be parsed")
+parser.add_argument("--indent", type=int, default=None, required=False, help="indent")
+parser.add_argument("--attrs", type=int, default=0, required=False, help="show attrs")
+
+args = parser.parse_args()
+
+parsed = ast.parse(args.content)
+indent = args.indent if args.indent != -1 else None
+print(ast.dump(parsed, include_attributes=args.attrs, indent=indent))


### PR DESCRIPTION
I had to make the following adjustments

**ASDL**
non-union types e.g. `arg` needed `attributes` which was being ignored by the the asdl generator

**handle pyNone and other Constants**
currently a hack this is something to deal with later. I'm not sure we can really get rid of pyTypes from the ast. Maybe we can. There's a comment in cPython asdl.h that's interesting (it was from 16 years ago)
```c
/* It would be nice if the code generated by asdl_c.py was completely
   independent of Python, but it is a goal the requires too much work
   at this stage.  So, for example, I'll represent identifiers as
   interned Python strings.
*/
```

Currently passes 523 out 560.

Seems to mostly fail on floats since it's not aware of the difference between 1.0 and 1 because it just treats numbers all the same. (no python types).