### PR TITLE
Deps and colors

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,4 @@
+export { parse } from "https://deno.land/std@0.99.0/flags/mod.ts";
+export * as Colors from "https://deno.land/std@0.99.0/fmt/colors.ts";
+export { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
+export * as esbuild from "https://deno.land/x/esbuild@v0.11.10/mod.js";

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.11.10/mod.js";
+import { esbuild } from "../deps.ts";
 // import * as esbuild from "esbuild";
 // deno run -A scripts/build.ts
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -2,14 +2,11 @@ import { GeneratedParser } from "./parser/generated_parser.ts";
 import { Tokenizer } from "./tokenize/Tokenizer.ts";
 import { tokenize } from "./tokenize/tokenize.ts";
 import { dump } from "./ast/ast.ts";
-
-import { readLines } from "https://deno.land/std@0.99.0/io/mod.ts";
-import { parse } from "https://deno.land/std@0.99.0/flags/mod.ts";
-import * as path from "https://deno.land/std@0.99.0/path/mod.ts";
+import { Colors, parse } from "../deps.ts";
 
 const args = parse(Deno.args);
 
-console.assert(args._.length == 1, "Must pass filename as argument");
+console.assert(args._.length == 1, Colors.bold(Colors.bgRed(Colors.white(" Must pass filename as argument "))));
 
 const filename = path.join(Deno.cwd(), args._[0] as string);
 
@@ -33,9 +30,9 @@ const tokens = tokenize(lineProducer(lines));
 
 const tokenizer = new Tokenizer(tokens);
 
-const parser = new GeneratedParser(tokenizer);
+const parser = new GeneratedParser(tokenizer, args.verbose || false);
 
 const ast = parser.file();
 
-console.log(JSON.stringify(ast, null, 2));
+console.log(Colors.green(JSON.stringify(ast, null, 2)));
 console.log(ast);

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -1,6 +1,6 @@
 import * as astnodes from "../src/ast/astnodes.ts";
 import { dump } from "../src/ast/ast.ts";
-import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
+import { assertEquals } from "../deps.ts";
 
 /** Simple name and function, compact form, but not configurable */
 async function getPyAstDump(content: string, indent: number | null = 4, attrs = false, js = false): Promise<string> {

--- a/tools/gen_parser/skulpt_parser_genarator.py
+++ b/tools/gen_parser/skulpt_parser_genarator.py
@@ -30,18 +30,19 @@ MODULE_PREFIX = """\
 import * as ast from "../ast/ast.ts";
 import * as astnodes from "../ast/astnodes.ts";
 import * as pegen_real from "./pegen.ts";
+import {{ Colors }} from "../../deps.ts";
 
 import {{memoize, memoize_left_rec, logger, Parser}} from "./parser.ts";
 
 const EXTRA = []; // todo
 
 const pegen = new Proxy(pegen_real, {{
-    get(target, prop, receiver) {{ 
+    get(target, prop, receiver) {{
         if (prop in target) {{
             return target[prop];
         }}
 
-        console.log("Missing pegen func!: " + prop);
+        console.log(Colors.yellow("Missing pegen func!: " + prop));
 
         return (...args) => args
     }}


### PR DESCRIPTION
**Dependencies**
Since deno doesn't do package management one best practice I've read is to move external imports to a `deps.ts` file. This way updating the urls in the future can be done in one place 

**Colors**
Because why not

**Verbose**
I added an optional verbose flag for the parser. The output is pretty gross but it might be useful for something.
Best used like `vr parse run-tests/t001.py --verbose > out.txt`
