### PR TITLE
imporve parser memoizing, typing and logging

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -11,7 +11,14 @@ const args = parse(Deno.args);
 
 console.assert(args._.length == 1, Colors.bold(Colors.bgRed(Colors.white(" Must pass filename as argument "))));
 
-const filename = args._[0] as string;
+const filearg = args._[0];
+
+let filename: string;
+if (typeof filearg === "number") {
+    filename = `run-tests/t${filearg.toString().padStart(3, "0")}.py`;
+} else {
+    filename = filearg;
+}
 
 const tokens = tokenize(readFile(filename));
 

--- a/src/tokenize/tokenize.ts
+++ b/src/tokenize/tokenize.ts
@@ -44,6 +44,9 @@ export class TokenInfo {
             return this.type;
         }
     }
+    get [Symbol.toStringTag]() {
+        return "TokenInfo";
+    }
 }
 
 const reRegExpChar = /[\\^$.*+?()[\]{}|]/g,


### PR DESCRIPTION
**Context** - there are two types of call signatures that are used by the Parser for memoized methods.
All methods take no arguments expect for `this.expect` which takes a single string.
So it seems silly to use a `...args` every time we call a memoized parser method.

**memoizing**
With the context in mind i've adjusted the memoize wrappers

**logging**
Some improvements to the output with the --verbose flag. Slightly more understandable.

**typing**
Tried to improve the typed call signatures for the wrapped memoize function and for the `positive/negative_lookahead` methods.
The lookahead methods compile when we turn the `//@ts-nocheck` off in the generated parser.


**parse.ts**
Convenience method `vr parse 1` =>  `vr parse run-tests/t001.py`

