### PR TITLE
Parse test

### DIFF
--- a/scripts.yml
+++ b/scripts.yml
@@ -50,7 +50,7 @@ scripts:
 
     parse:
         desc: takes in a filename or number as the first argument. Optional --verbose (-v) flag
-        cmd: deno run src/parse.ts
+        cmd: deno run scripts/parse.ts
         allow:
             - read
             - run

--- a/scripts.yml
+++ b/scripts.yml
@@ -42,7 +42,8 @@ scripts:
         cmd: cd ../cpython/Grammar && git diff -- python.gram -p > ../../skulpt_parser/tools/patch/grammar.patch
 
     test:
-        cmd: deno test
+        desc: run all tests or include a short name <dump|parse>
+        cmd: deno run scripts/test.ts
         allow:
             - read
             - run

--- a/scripts/parse.ts
+++ b/scripts/parse.ts
@@ -1,8 +1,8 @@
-import { dump } from "./ast/dump.ts";
+import { dump } from "../src/ast/dump.ts";
 import { Colors, parse } from "../deps.ts";
 import { getDiff } from "../support/diff.ts";
 import { getPyAstDump } from "../support/py_ast_dump.ts";
-import { runParserFromFile } from "./parser/parse.ts";
+import { runParserFromFile } from "../src/parser/parse.ts";
 
 const args = parse(Deno.args);
 const options = { indent: 2, include_attributes: true };

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,0 +1,23 @@
+import { parse } from "../deps.ts";
+
+const args = parse(Deno.args);
+const test = args._?.[0];
+
+const extra = [];
+
+switch (test) {
+    case "parse":
+        extra.push("tests/parse.test.ts");
+        break;
+    /** @todo the default should be to do nothing here and run all the tests */
+    case "dump":
+    default:
+        extra.push("tests/ast_dump.test.ts");
+        break;
+}
+
+const cmd = Deno.run({
+    cmd: ["deno", "test", "--allow-read", "--allow-run", ...extra],
+});
+
+await cmd.status();

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,2 +1,2 @@
 export { tokenize } from "./tokenize/tokenize.ts";
-export { readline, Tokenizer } from "./tokenize/Tokenizer.ts";
+export { Tokenizer } from "./tokenize/Tokenizer.ts";

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,13 +1,11 @@
-import { GeneratedParser } from "./parser/generated_parser.ts";
-import { Tokenizer } from "./tokenize/Tokenizer.ts";
-import { tokenize } from "./tokenize/tokenize.ts";
-import { readFile } from "./tokenize/readline.ts";
 import { dump } from "./ast/dump.ts";
 import { Colors, parse } from "../deps.ts";
 import { getDiff } from "../support/diff.ts";
 import { getPyAstDump } from "../support/py_ast_dump.ts";
+import { runParserFromFile } from "./parser/parse.ts";
 
 const args = parse(Deno.args);
+const options = { indent: 2, include_attributes: true };
 
 console.assert(args._.length == 1, Colors.bold(Colors.bgRed(Colors.white(" Must pass filename as argument "))));
 
@@ -20,24 +18,14 @@ if (typeof filearg === "number") {
     filename = filearg;
 }
 
-const tokens = tokenize(readFile(filename));
-
-const tokenizer = new Tokenizer(tokens);
-
-const parser = new GeneratedParser(tokenizer, args.v || args.verbose || false);
-
-const ast = parser.file();
-
 console.log();
-
-const options = { indent: 2, include_attributes: true };
-
 console.log(Colors.bold(Colors.magenta("##### py #####")));
 const pyDump = await getPyAstDump(Deno.readTextFileSync(filename), options);
 console.log(Colors.magenta(pyDump));
 console.log();
 
 let jsDump = "";
+const ast = runParserFromFile(filename, null, args);
 if (ast !== null) {
     try {
         jsDump = dump(ast, options);

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,0 +1,27 @@
+import { tokenizerFromFile, tokenizerFromString } from "../tokenize/mod.ts";
+import { GeneratedParser } from "./generated_parser.ts";
+
+/**@todo start_rule -  we can also probaly just make .parse() this into a method on the parser itself since it should know it's own startrule*/
+export function parse(p: GeneratedParser, start_rule: number | null = 256) {
+    // if (mode === 256) {
+    return p.file();
+    // }
+}
+
+export function runParserFromString(
+    text: string,
+    start_rule: number | null = 256,
+    flags: { [flag: string]: any } = {}
+) {
+    const parser = new GeneratedParser(tokenizerFromString(text), !!(flags.v || flags.verbose));
+    return parse(parser, start_rule);
+}
+
+export function runParserFromFile(
+    filename: string,
+    start_rule: number | null = 256,
+    flags: { [flag: string]: any } = {}
+) {
+    const parser = new GeneratedParser(tokenizerFromFile(filename), !!(flags.v || flags.verbose));
+    return parse(parser, start_rule);
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,7 +1,9 @@
 import { NAME, NUMBER, OP, STRING, tok_name } from "../tokenize/token.ts";
-import { exact_token_types, Tokenizer } from "../tokenize/Tokenizer.ts";
+import { exact_token_types } from "../tokenize/Tokenizer.ts";
+import type { Tokenizer } from "../tokenize/Tokenizer.ts";
 import { tokens } from "../tokenize/token.ts";
-import { pySyntaxError, TokenInfo } from "../tokenize/tokenize.ts";
+import { pySyntaxError } from "../tokenize/tokenize.ts";
+import type { TokenInfo } from "../tokenize/tokenize.ts";
 import { Name, Load, TypeIgnore, Constant } from "../ast/astnodes.ts";
 
 /** If we have a memoized parser method that has a different call signature we'd need to adapt this */

--- a/src/parser/pegen.ts
+++ b/src/parser/pegen.ts
@@ -12,7 +12,7 @@ import {
     exprKind,
     cmpop,
 } from "../ast/astnodes.ts";
-import { TokenInfo } from "../tokenize/tokenize.ts";
+import type { TokenInfo } from "../tokenize/tokenize.ts";
 import { Parser } from "./parser.ts";
 import { CmpopExprPair, KeyValuePair, KeywordOrStarred } from "./pegen_types.ts";
 

--- a/src/tokenize/Tokenizer.ts
+++ b/src/tokenize/Tokenizer.ts
@@ -1,6 +1,6 @@
 import { isSpace } from "../util/str_helpers.ts";
 import { COMMENT, ERRORTOKEN, EXACT_TOKEN_TYPES, NL } from "./token.ts";
-import { TokenInfo } from "./tokenize.ts";
+import type { TokenInfo } from "./tokenize.ts";
 
 export const exact_token_types = EXACT_TOKEN_TYPES;
 

--- a/src/tokenize/mod.ts
+++ b/src/tokenize/mod.ts
@@ -1,0 +1,11 @@
+import { readFile, readString } from "./readline.ts";
+import { tokenize } from "./tokenize.ts";
+import { Tokenizer } from "./Tokenizer.ts";
+
+export function tokenizerFromString(text: string) {
+    return new Tokenizer(tokenize(readString(text)));
+}
+
+export function tokenizerFromFile(filename: string) {
+    return new Tokenizer(tokenize(readFile(filename)));
+}

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -69,4 +69,4 @@ async function doTest(source: string) {
 
 const files: string[] = [];
 
-await runTests(doTest, { files, skip: new Set(), exitEarly: false });
+await runTests(doTest, { files, skip: new Set(), failFast: false });

--- a/tests/ast_dump.test.ts
+++ b/tests/ast_dump.test.ts
@@ -4,6 +4,7 @@ import { dump } from "../src/ast/dump.ts";
 import { getPyAstDump } from "../support/py_ast_dump.ts";
 // replace with assertEquals when string comparison is better.
 import { assertEqualsString } from "../support/diff.ts";
+import { runTests } from "./run_tests_helper.ts";
 
 /** helper function to generate an ast tree that can be converted in typescript - you'll need to add in missing null values */
 async function convertToTs(content: string): Promise<string> {
@@ -45,11 +46,20 @@ async function convertFileToTs(fileName: string) {
     return jsAST;
 }
 
-async function doTest(source: string, mod: astnodes.Module) {
+async function doTest(source: string) {
+    astnodes;
+    pyFloat;
+    pyInt;
+    pyStr;
+    pyTrue;
+    pyFalse;
+    pyNone;
+
+    const converted = await convertToTs(source);
+    const jsAST = eval(converted) as astnodes.mod;
     const indent = [0, 2, 4, null][Math.floor(Math.random() * 4)];
-    const include_attributes = true;
-    const pyDump = await getPyAstDump(source, { indent, include_attributes });
-    const jsDump = dump(mod, { indent, include_attributes });
+    const pyDump = await getPyAstDump(source, { indent, include_attributes: true });
+    const jsDump = dump(jsAST, { indent, include_attributes: true });
     assertEqualsString(jsDump, pyDump);
 }
 
@@ -57,43 +67,6 @@ async function doTest(source: string, mod: astnodes.Module) {
 // console.log(dump(await convertFileToTs(tmp), {indent: 2, include_attributes: true}));
 // const files = [tmp];
 
-const files = [];
-for await (const dirEntry of Deno.readDir("run-tests/")) {
-    if (!dirEntry.name.endsWith(".py")) {
-        continue;
-    }
-    files.push(dirEntry.name);
-}
-files.sort();
-const skip = new Set();
+const files: string[] = [];
 
-for (const test of files) {
-    if (skip.has(test)) {
-        continue;
-    }
-    Deno.test({
-        name: test,
-        fn: async () => {
-            new astnodes.Module([], []); // fails without this
-            pyFloat;
-            pyInt;
-            pyStr;
-            pyTrue;
-            pyFalse;
-            pyNone;
-            try {
-                const text = await Deno.readTextFile("run-tests/" + test);
-                const converted = await convertToTs(text);
-                const jsAST = eval(converted);
-                await doTest(text, jsAST);
-            } catch (e) {
-                // // uncomment these to exit at the first fail
-                // console.error(e);
-                // Deno.exit(0);
-                throw e;
-            }
-        },
-        sanitizeExit: false,
-        // allow us to exit early with Deno.exit
-    });
-}
+await runTests(doTest, { files, skip: new Set(), exitEarly: false });

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -1,0 +1,23 @@
+import { dump } from "../src/ast/dump.ts";
+import { getPyAstDump } from "../support/py_ast_dump.ts";
+// replace with assertEquals when string comparison is better.
+import { assertEqualsString } from "../support/diff.ts";
+import { runParserFromString } from "../src/parser/parse.ts";
+import { runTests } from "./run_tests_helper.ts";
+
+const options = { indent: 2, include_attributes: true };
+
+async function doTest(source: string) {
+    const pyDump = await getPyAstDump(source, options);
+    const jsAST = runParserFromString(source);
+    const jsDump = jsAST === null ? "null" : dump(jsAST, options);
+    assertEqualsString(jsDump, pyDump);
+}
+
+/* for debugging */
+// const tmp = "t004.py";
+// const files = [tmp];
+
+const files: string[] = [];
+
+await runTests(doTest, { files, skip: new Set(), exitEarly: false });

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -20,4 +20,4 @@ async function doTest(source: string) {
 
 const files: string[] = [];
 
-await runTests(doTest, { files, skip: new Set(), exitEarly: false });
+await runTests(doTest, { files, skip: new Set(), failFast: false });

--- a/tests/run_tests_helper.ts
+++ b/tests/run_tests_helper.ts
@@ -11,11 +11,11 @@ async function populateFiles(files: string[]) {
 interface runTestsOptions {
     files?: string[];
     skip?: Set<string>;
-    exitEarly?: boolean;
+    failFast?: boolean;
 }
 
 export async function runTests(doTest: (text: string) => void, options: runTestsOptions = {}) {
-    const { files = [], skip = new Set(), exitEarly = false } = options;
+    const { files = [], skip = new Set(), failFast = false } = options;
     if (files.length === 0) {
         await populateFiles(files);
     }
@@ -31,7 +31,7 @@ export async function runTests(doTest: (text: string) => void, options: runTests
                     const text = await Deno.readTextFile("run-tests/" + test);
                     await doTest(text);
                 } catch (e) {
-                    if (exitEarly) {
+                    if (failFast) {
                         console.error(e);
                         Deno.exit(0);
                     } else {

--- a/tests/run_tests_helper.ts
+++ b/tests/run_tests_helper.ts
@@ -1,0 +1,46 @@
+async function populateFiles(files: string[]) {
+    for await (const dirEntry of Deno.readDir("run-tests/")) {
+        if (!dirEntry.name.endsWith(".py")) {
+            continue;
+        }
+        files.push(dirEntry.name);
+    }
+    files.sort();
+}
+
+interface runTestsOptions {
+    files?: string[];
+    skip?: Set<string>;
+    exitEarly?: boolean;
+}
+
+export async function runTests(doTest: (text: string) => void, options: runTestsOptions = {}) {
+    const { files = [], skip = new Set(), exitEarly = false } = options;
+    if (files.length === 0) {
+        await populateFiles(files);
+    }
+
+    for (const test of files) {
+        if (skip.has(test)) {
+            continue;
+        }
+        Deno.test({
+            name: test,
+            fn: async () => {
+                try {
+                    const text = await Deno.readTextFile("run-tests/" + test);
+                    await doTest(text);
+                } catch (e) {
+                    if (exitEarly) {
+                        console.error(e);
+                        Deno.exit(0);
+                    } else {
+                        throw e;
+                    }
+                }
+            },
+            sanitizeExit: false,
+            // allow us to exit early with Deno.exit
+        });
+    }
+}


### PR DESCRIPTION
close #26 

The output is pretty nasty because of all the logging from the generated parser. 
That can be cleaned up in another commit. When I was working with it i just commented out the Proxy pegen logging statements.

We currently pass 63 out of 560 tests 😄 

Other enhancements could be some flags e.g. `--fail-fast`
