### PR TITLE
pegen and types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 dist/*
 *__pycache__
 .idea/
-*tmp.txt
+*tmp.*

--- a/src/ast/constants.ts
+++ b/src/ast/constants.ts
@@ -54,7 +54,11 @@ export class pyBool extends pyConstant<boolean> {
     }
 }
 
-export class pyEllipsisType extends pyConstant<"..."> {}
+export class pyEllipsisType extends pyConstant<"..."> {
+    toString() {
+        return "Ellipsis";
+    }
+}
 
 export const pyNone = new pyNoneType(null);
 export const pyTrue = new pyBool(true);

--- a/src/parser/generated_parser.ts
+++ b/src/parser/generated_parser.ts
@@ -17,6 +17,7 @@ import type {
     Call,
     FunctionDef,
     AsyncFunctionDef,
+    Starred,
 } from "../ast/astnodes.ts";
 import type {
     StartRule,
@@ -2900,7 +2901,7 @@ export class GeneratedParser extends Parser {
     }
 
     @memoize
-    starred_expression(): expr | null {
+    starred_expression(): Starred | null {
         // starred_expression: '*' expression
         let a, literal;
         const mark = this.mark();

--- a/src/parser/generated_parser.ts
+++ b/src/parser/generated_parser.ts
@@ -15,6 +15,8 @@ import type {
     comprehension,
     Name,
     Call,
+    FunctionDef,
+    AsyncFunctionDef,
 } from "../ast/astnodes.ts";
 import type {
     StartRule,

--- a/src/parser/generated_parser.ts
+++ b/src/parser/generated_parser.ts
@@ -47,11 +47,9 @@ function CHECK_VERSION(i: number, msg: string, ret: any) {
 }
 
 /** @todo */
-function CHECK_NULL_ALLOWED(p: Parser, result: any) {
+function CHECK_NULL_ALLOWED(result: any) {
     return result;
 }
-
-type KeywordOrStarredArray = KeywordOrStarred[];
 
 export class GeneratedParser extends Parser {
     start_rule: StartRule;
@@ -1090,7 +1088,7 @@ export class GeneratedParser extends Parser {
     }
 
     @memoize
-    function_def(): stmt | null {
+    function_def(): FunctionDef | AsyncFunctionDef | null {
         // function_def: decorators function_def_raw | function_def_raw
         let d, f, function_def_raw;
         const mark = this.mark();
@@ -1107,7 +1105,7 @@ export class GeneratedParser extends Parser {
     }
 
     @memoize
-    function_def_raw(): stmt | null {
+    function_def_raw(): FunctionDef | AsyncFunctionDef | null {
         // function_def_raw: 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block | ASYNC 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
         let a, async, b, keyword, literal, literal_1, literal_2, n, params, tc;
         const mark = this.mark();
@@ -2879,7 +2877,7 @@ export class GeneratedParser extends Parser {
     }
 
     @memoize
-    kwargs(): KeywordOrStarredArray | null {
+    kwargs(): KeywordOrStarred[] | null {
         // kwargs: ','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+ | ','.kwarg_or_starred+ | ','.kwarg_or_double_starred+
         let _gather_112, _gather_114, a, b, literal;
         const mark = this.mark();
@@ -2942,12 +2940,12 @@ export class GeneratedParser extends Parser {
         const mark = this.mark();
         if ((a = this.name()) && (literal = this.expect("=")) && (b = this.expression())) {
             const EXTRA = this.extra(mark);
-            return pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), 1);
+            return pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true);
         }
         this.reset(mark);
         if ((literal = this.expect("**")) && (a = this.expression())) {
             const EXTRA = this.extra(mark);
-            return pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(null, a, ...EXTRA)), 1);
+            return pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(null, a, ...EXTRA)), true);
         }
         this.reset(mark);
         if ((invalid_kwarg = this.invalid_kwarg())) {

--- a/src/parser/generated_parser.ts
+++ b/src/parser/generated_parser.ts
@@ -23,7 +23,6 @@ import type {
     StartRule,
     CmpopExprPair,
     KeyValuePair,
-    KeywordOrStarred,
     NameDefaultPair,
     SlashWithDefault,
     StarEtc,
@@ -34,7 +33,7 @@ import type { TokenInfo } from "../tokenize/tokenize.ts";
 import * as astnodes from "../ast/astnodes.ts";
 import { pyNone, pyTrue, pyFalse, pyEllipsis } from "../ast/constants.ts";
 import { pegen } from "./pegen_proxy.ts";
-import { KeywordToken } from "./pegen_types.ts";
+import { KeywordToken, KeywordOrStarred } from "./pegen_types.ts";
 import { FILE_INPUT, SINGLE_INPUT, EVAL_INPUT, FUNC_TYPE_INPUT, FSTRING_INPUT } from "./pegen_types.ts";
 
 import { memoize, memoizeLeftRec, logger, Parser } from "./parser.ts";
@@ -2921,11 +2920,11 @@ export class GeneratedParser extends Parser {
         const mark = this.mark();
         if ((a = this.name()) && (literal = this.expect("=")) && (b = this.expression())) {
             const EXTRA = this.extra(mark);
-            return pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true);
+            return new KeywordOrStarred(CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true);
         }
         this.reset(mark);
         if ((a = this.starred_expression())) {
-            return pegen.keyword_or_starred(this, a, false);
+            return new KeywordOrStarred(a, false);
         }
         this.reset(mark);
         if ((invalid_kwarg = this.invalid_kwarg())) {
@@ -2943,12 +2942,12 @@ export class GeneratedParser extends Parser {
         const mark = this.mark();
         if ((a = this.name()) && (literal = this.expect("=")) && (b = this.expression())) {
             const EXTRA = this.extra(mark);
-            return pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true);
+            return new KeywordOrStarred(CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true);
         }
         this.reset(mark);
         if ((literal = this.expect("**")) && (a = this.expression())) {
             const EXTRA = this.extra(mark);
-            return pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(null, a, ...EXTRA)), true);
+            return new KeywordOrStarred(CHECK(new astnodes.keyword(null, a, ...EXTRA)), true);
         }
         this.reset(mark);
         if ((invalid_kwarg = this.invalid_kwarg())) {

--- a/src/parser/pegen.ts
+++ b/src/parser/pegen.ts
@@ -18,6 +18,7 @@ import {
     keyword,
     FunctionDef,
     AsyncFunctionDef,
+    Starred,
 } from "../ast/astnodes.ts";
 import { DOT, ELLIPSIS, NAME } from "../tokenize/token.ts";
 import type { TokenInfo } from "../tokenize/tokenize.ts";
@@ -2339,8 +2340,16 @@ export function keyword_or_starred(p: Parser, element: keyword, is_keyword: bool
 //     return n;
 // }
 
-export function seq_extract_starred_exprs(p: Parser, kwargs: KeywordOrStarred[]): expr[] {
-    return kwargs.filter((kw) => !kw.is_keyword).map((kw) => kw.element);
+function isKeyword(kw: KeywordOrStarred): kw is KeywordOrStarred<true> {
+    return kw.is_keyword;
+}
+
+function isStarred(kw: KeywordOrStarred): kw is KeywordOrStarred<false> {
+    return !kw.is_keyword;
+}
+
+export function seq_extract_starred_exprs(p: Parser, kwargs: KeywordOrStarred[]): Starred[] {
+    return kwargs.filter(isStarred).map((kw) => kw.element);
 }
 
 // /* Extract the starred expressions of an asdl_seq* of KeywordOrStarred*s */
@@ -2367,7 +2376,7 @@ export function seq_extract_starred_exprs(p: Parser, kwargs: KeywordOrStarred[])
 // }
 
 export function seq_delete_starred_exprs(p: Parser, kwargs: KeywordOrStarred[]): keyword[] {
-    return kwargs.filter((kw) => kw.is_keyword).map((kw) => kw.element as keyword);
+    return kwargs.filter(isKeyword).map((kw) => kw.element);
 }
 
 // /* Return a new asdl_seq* with only the keywords in kwargs */

--- a/src/parser/pegen.ts
+++ b/src/parser/pegen.ts
@@ -19,6 +19,7 @@ import {
     FunctionDef,
     AsyncFunctionDef,
     Starred,
+    alias,
 } from "../ast/astnodes.ts";
 import { DOT, ELLIPSIS, NAME } from "../tokenize/token.ts";
 import type { TokenInfo } from "../tokenize/tokenize.ts";
@@ -1592,7 +1593,12 @@ export function seq_count_dots(seq: TokenInfo[]) {
 //     return number_of_dots;
 // }
 
-// /* Creates an alias with '*' as the identifier name */
+/* Creates an alias with '*' as the identifier name */
+export function alias_for_star(p: Parser) {
+    /** @todo should we inline this? */
+    return new alias("*", null);
+}
+
 // alias_ty
 // _PyPegen_alias_for_star(Parser *p)
 // {

--- a/src/parser/pegen.ts
+++ b/src/parser/pegen.ts
@@ -2309,9 +2309,6 @@ kwarg_or_starred[KeywordOrStarred*]:
     | a=starred_expression { _PyPegen_keyword_or_starred(p, a, 0) } <<-- here
     | invalid_kwarg
 */
-export function keyword_or_starred(p: Parser, element: keyword, is_keyword: boolean) {
-    return new KeywordOrStarred(element, is_keyword);
-}
 
 // /* Construct a KeywordOrStarred */
 // KeywordOrStarred *

--- a/src/parser/pegen_types.ts
+++ b/src/parser/pegen_types.ts
@@ -58,7 +58,7 @@ type KeywordOrStarredElement<IsKeyword> = IsKeyword extends true
     ? keyword
     : IsKeyword extends false
     ? Starred
-    : Starred | keyword;
+    : keyword | Starred;
 
 export class KeywordOrStarred<IsKeyword extends boolean = boolean> {
     element: KeywordOrStarredElement<IsKeyword>;

--- a/src/parser/pegen_types.ts
+++ b/src/parser/pegen_types.ts
@@ -1,4 +1,4 @@
-import { arg, cmpop, expr, keyword, operator } from "../ast/astnodes.ts";
+import { arg, cmpop, expr, keyword, operator, Starred } from "../ast/astnodes.ts";
 
 export class CmpopExprPair {
     cmpop: cmpop;
@@ -54,11 +54,17 @@ export class StarEtc {
     }
 }
 
-export class KeywordOrStarred {
-    element: keyword | expr;
-    is_keyword: boolean;
+type KeywordOrStarredElement<IsKeyword> = IsKeyword extends true
+    ? keyword
+    : IsKeyword extends false
+    ? Starred
+    : Starred | keyword;
 
-    constructor(element: keyword | expr, is_keyword: boolean) {
+export class KeywordOrStarred<IsKeyword extends boolean = boolean> {
+    element: KeywordOrStarredElement<IsKeyword>;
+    is_keyword: IsKeyword;
+
+    constructor(element: KeywordOrStarredElement<IsKeyword>, is_keyword: IsKeyword) {
         this.element = element;
         this.is_keyword = is_keyword;
     }

--- a/tools/gen_parser/skulpt_parser_genarator.py
+++ b/tools/gen_parser/skulpt_parser_genarator.py
@@ -42,7 +42,7 @@ MODULE_PREFIX = """\
 // deno-lint-ignore-file no-explicit-any camelcase no-unused-vars
 // @ts-nocheck
 
-import type {{ mod, expr, stmt, operator, alias, withitem, excepthandler, arguments_, arg, comprehension, Name, Call, FunctionDef, AsyncFunctionDef }} from "../ast/astnodes.ts";
+import type {{ mod, expr, stmt, operator, alias, withitem, excepthandler, arguments_, arg, comprehension, Name, Call, FunctionDef, AsyncFunctionDef, Starred }} from "../ast/astnodes.ts";
 import type {{ StartRule, CmpopExprPair, KeyValuePair, KeywordOrStarred, NameDefaultPair, SlashWithDefault, StarEtc, AugOperator }} from "./pegen_types.ts";
 import type {{ Tokenizer }} from "../tokenize/Tokenizer.ts";
 import type {{ TokenInfo }} from "../tokenize/tokenize.ts";

--- a/tools/gen_parser/skulpt_parser_genarator.py
+++ b/tools/gen_parser/skulpt_parser_genarator.py
@@ -43,13 +43,13 @@ MODULE_PREFIX = """\
 // @ts-nocheck
 
 import type {{ mod, expr, stmt, operator, alias, withitem, excepthandler, arguments_, arg, comprehension, Name, Call, FunctionDef, AsyncFunctionDef, Starred }} from "../ast/astnodes.ts";
-import type {{ StartRule, CmpopExprPair, KeyValuePair, KeywordOrStarred, NameDefaultPair, SlashWithDefault, StarEtc, AugOperator }} from "./pegen_types.ts";
+import type {{ StartRule, CmpopExprPair, KeyValuePair, NameDefaultPair, SlashWithDefault, StarEtc, AugOperator }} from "./pegen_types.ts";
 import type {{ Tokenizer }} from "../tokenize/Tokenizer.ts";
 import type {{ TokenInfo }} from "../tokenize/tokenize.ts";
 import * as astnodes from "../ast/astnodes.ts";
 import {{ pyNone, pyTrue, pyFalse, pyEllipsis }} from "../ast/constants.ts";
 import {{ pegen }} from "./pegen_proxy.ts";
-import {{ KeywordToken }} from "./pegen_types.ts";
+import {{ KeywordToken, KeywordOrStarred }} from "./pegen_types.ts";
 import {{ FILE_INPUT, SINGLE_INPUT, EVAL_INPUT, FUNC_TYPE_INPUT, FSTRING_INPUT }} from "./pegen_types.ts";
 
 import {{ memoize, memoizeLeftRec, logger, Parser}} from "./parser.ts";

--- a/tools/gen_parser/skulpt_parser_genarator.py
+++ b/tools/gen_parser/skulpt_parser_genarator.py
@@ -42,7 +42,7 @@ MODULE_PREFIX = """\
 // deno-lint-ignore-file no-explicit-any camelcase no-unused-vars
 // @ts-nocheck
 
-import type {{ mod, expr, stmt, operator, alias, withitem, excepthandler, arguments_, arg, comprehension, Name, Call }} from "../ast/astnodes.ts";
+import type {{ mod, expr, stmt, operator, alias, withitem, excepthandler, arguments_, arg, comprehension, Name, Call, FunctionDef, AsyncFunctionDef }} from "../ast/astnodes.ts";
 import type {{ StartRule, CmpopExprPair, KeyValuePair, KeywordOrStarred, NameDefaultPair, SlashWithDefault, StarEtc, AugOperator }} from "./pegen_types.ts";
 import type {{ Tokenizer }} from "../tokenize/Tokenizer.ts";
 import type {{ TokenInfo }} from "../tokenize/tokenize.ts";

--- a/tools/gen_parser/skulpt_parser_genarator.py
+++ b/tools/gen_parser/skulpt_parser_genarator.py
@@ -65,11 +65,9 @@ function CHECK_VERSION(i: number, msg: string, ret: any) {{
 }}
 
 /** @todo */
-function CHECK_NULL_ALLOWED(p: Parser, result: any) {{
+function CHECK_NULL_ALLOWED(result: any) {{
     return result;
 }}
-
-type KeywordOrStarredArray = KeywordOrStarred[]
 
 """
 
@@ -132,6 +130,11 @@ reserved = {
 
 def fix_reserved(name):
     return name + "_" if name in reserved else name
+
+
+def clean_type(type):
+    # because grammar doesn't allow certain characters
+    return type.replace("_UNION_", "|").replace("_ARRAY", "[]")
 
 
 non_exact_tok = (
@@ -356,7 +359,7 @@ export class GeneratedParser extends Parser {
                 self.print("@logger")
         else:
             self.print("@memoize")
-        node_type = node.type or "any"
+        node_type = clean_type(node.type or "any")
         self.print(f"{node.name}(): {node_type} | null {{")  # -> Optional[{node_type}] {{")
         with self.indent():
             self.print(f"// {node.name}: {rhs}")

--- a/tools/patch/grammar.patch
+++ b/tools/patch/grammar.patch
@@ -1,5 +1,5 @@
 diff --git a/Grammar/python.gram b/Grammar/python.gram
-index 64e205e7fd..6fc9c84270 100644
+index 64e205e7fd..99182cfaca 100644
 --- a/Grammar/python.gram
 +++ b/Grammar/python.gram
 @@ -2,7 +2,7 @@
@@ -841,16 +841,16 @@ index 64e205e7fd..6fc9c84270 100644
      | a=NAME '=' b=expression {
 -        _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
 -    | a=starred_expression { _PyPegen_keyword_or_starred(p, a, 0) }
-+        pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true) }
-+    | a=starred_expression { pegen.keyword_or_starred(this, a, false) }
++        new KeywordOrStarred(CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true) }
++    | a=starred_expression { new KeywordOrStarred(a, false) }
      | invalid_kwarg
 -kwarg_or_double_starred[KeywordOrStarred*]:
 +kwarg_or_double_starred[KeywordOrStarred]:
      | a=NAME '=' b=expression {
 -        _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
 -    | '**' a=expression { _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(NULL, a, EXTRA)), 1) }
-+        pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true) }
-+    | '**' a=expression { pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(null, a, ...EXTRA)), true) }
++        new KeywordOrStarred(CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true) }
++    | '**' a=expression { new KeywordOrStarred(CHECK(new astnodes.keyword(null, a, ...EXTRA)), true) }
      | invalid_kwarg
  
  # NOTE: star_targets may contain *bitwise_or, targets may not.

--- a/tools/patch/grammar.patch
+++ b/tools/patch/grammar.patch
@@ -1,5 +1,5 @@
 diff --git a/Grammar/python.gram b/Grammar/python.gram
-index 64e205e7fd..ddc442a97b 100644
+index 64e205e7fd..c9bea63124 100644
 --- a/Grammar/python.gram
 +++ b/Grammar/python.gram
 @@ -2,7 +2,7 @@
@@ -296,12 +296,12 @@ index 64e205e7fd..ddc442a97b 100644
  
 -function_def[stmt_ty]:
 -    | d=decorators f=function_def_raw { _PyPegen_function_def_decorators(p, d, f) }
-+function_def[stmt]:
++function_def[FunctionDef_UNION_AsyncFunctionDef]:
 +    | d=decorators f=function_def_raw { pegen.function_def_decorators(this, d, f) }
      | function_def_raw
  
 -function_def_raw[stmt_ty]:
-+function_def_raw[stmt]:
++function_def_raw[FunctionDef_UNION_AsyncFunctionDef]:
      | 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
 -        _Py_FunctionDef(n->v.Name.id,
 -                        (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
@@ -828,7 +828,7 @@ index 64e205e7fd..ddc442a97b 100644
 +                          CHECK_NULL_ALLOWED(pegen.seq_extract_starred_exprs(this, a)),
 +                          CHECK_NULL_ALLOWED(pegen.seq_delete_starred_exprs(this, a)),
 +                          ...EXTRA) }
-+kwargs[KeywordOrStarredArray]:
++kwargs[KeywordOrStarred_ARRAY]:
 +    | a=','.kwarg_or_starred+ ',' b=','.kwarg_or_double_starred+ { pegen.join_sequences(this, a, b) }
      | ','.kwarg_or_starred+
      | ','.kwarg_or_double_starred+
@@ -849,8 +849,8 @@ index 64e205e7fd..ddc442a97b 100644
      | a=NAME '=' b=expression {
 -        _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
 -    | '**' a=expression { _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(NULL, a, EXTRA)), 1) }
-+        pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), 1) }
-+    | '**' a=expression { pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(null, a, ...EXTRA)), 1) }
++        pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(a.id, b, ...EXTRA)), true) }
++    | '**' a=expression { pegen.keyword_or_starred(this, CHECK(new astnodes.keyword(null, a, ...EXTRA)), true) }
      | invalid_kwarg
  
  # NOTE: star_targets may contain *bitwise_or, targets may not.

--- a/tools/patch/grammar.patch
+++ b/tools/patch/grammar.patch
@@ -1,5 +1,5 @@
 diff --git a/Grammar/python.gram b/Grammar/python.gram
-index 64e205e7fd..c9bea63124 100644
+index 64e205e7fd..6fc9c84270 100644
 --- a/Grammar/python.gram
 +++ b/Grammar/python.gram
 @@ -2,7 +2,7 @@
@@ -835,7 +835,7 @@ index 64e205e7fd..c9bea63124 100644
 -starred_expression[expr_ty]:
 -    | '*' a=expression { _Py_Starred(a, Load, EXTRA) }
 -kwarg_or_starred[KeywordOrStarred*]:
-+starred_expression[expr]:
++starred_expression[Starred]:
 +    | '*' a=expression { new astnodes.Starred(a, astnodes.Load, ...EXTRA) }
 +kwarg_or_starred[KeywordOrStarred]:
      | a=NAME '=' b=expression {


### PR DESCRIPTION
implements `join_names_with_dot` and `function_def_decorators`. 
Idea for Union and Array types in the grammar patch