### PR TITLE
inline some pygen types

### DIFF
--- a/src/parser/generated_parser.ts
+++ b/src/parser/generated_parser.ts
@@ -19,21 +19,22 @@ import type {
     AsyncFunctionDef,
     Starred,
 } from "../ast/astnodes.ts";
-import type {
+import type { Tokenizer } from "../tokenize/Tokenizer.ts";
+import type { TokenInfo } from "../tokenize/tokenize.ts";
+import * as astnodes from "../ast/astnodes.ts";
+import { pyNone, pyTrue, pyFalse, pyEllipsis } from "../ast/constants.ts";
+import {
     StartRule,
     CmpopExprPair,
     KeyValuePair,
+    KeywordToken,
+    KeywordOrStarred,
     NameDefaultPair,
     SlashWithDefault,
     StarEtc,
     AugOperator,
 } from "./pegen_types.ts";
-import type { Tokenizer } from "../tokenize/Tokenizer.ts";
-import type { TokenInfo } from "../tokenize/tokenize.ts";
-import * as astnodes from "../ast/astnodes.ts";
-import { pyNone, pyTrue, pyFalse, pyEllipsis } from "../ast/constants.ts";
 import { pegen } from "./pegen_proxy.ts";
-import { KeywordToken, KeywordOrStarred } from "./pegen_types.ts";
 import { FILE_INPUT, SINGLE_INPUT, EVAL_INPUT, FUNC_TYPE_INPUT, FSTRING_INPUT } from "./pegen_types.ts";
 
 import { memoize, memoizeLeftRec, logger, Parser } from "./parser.ts";
@@ -463,55 +464,55 @@ export class GeneratedParser extends Parser {
         let literal;
         const mark = this.mark();
         if ((literal = this.expect("+="))) {
-            return pegen.augoperator(this, astnodes.Add);
+            return new AugOperator(astnodes.Add);
         }
         this.reset(mark);
         if ((literal = this.expect("-="))) {
-            return pegen.augoperator(this, astnodes.Sub);
+            return new AugOperator(astnodes.Sub);
         }
         this.reset(mark);
         if ((literal = this.expect("*="))) {
-            return pegen.augoperator(this, astnodes.Mult);
+            return new AugOperator(astnodes.Mult);
         }
         this.reset(mark);
         if ((literal = this.expect("@="))) {
-            return CHECK_VERSION(5, "The '@' operator is", pegen.augoperator(this, astnodes.MatMult));
+            return CHECK_VERSION(5, "The '@' operator is", new AugOperator(astnodes.MatMult));
         }
         this.reset(mark);
         if ((literal = this.expect("/="))) {
-            return pegen.augoperator(this, astnodes.Div);
+            return new AugOperator(astnodes.Div);
         }
         this.reset(mark);
         if ((literal = this.expect("%="))) {
-            return pegen.augoperator(this, astnodes.Mod);
+            return new AugOperator(astnodes.Mod);
         }
         this.reset(mark);
         if ((literal = this.expect("&="))) {
-            return pegen.augoperator(this, astnodes.BitAnd);
+            return new AugOperator(astnodes.BitAnd);
         }
         this.reset(mark);
         if ((literal = this.expect("|="))) {
-            return pegen.augoperator(this, astnodes.BitOr);
+            return new AugOperator(astnodes.BitOr);
         }
         this.reset(mark);
         if ((literal = this.expect("^="))) {
-            return pegen.augoperator(this, astnodes.BitXor);
+            return new AugOperator(astnodes.BitXor);
         }
         this.reset(mark);
         if ((literal = this.expect("<<="))) {
-            return pegen.augoperator(this, astnodes.LShift);
+            return new AugOperator(astnodes.LShift);
         }
         this.reset(mark);
         if ((literal = this.expect(">>="))) {
-            return pegen.augoperator(this, astnodes.RShift);
+            return new AugOperator(astnodes.RShift);
         }
         this.reset(mark);
         if ((literal = this.expect("**="))) {
-            return pegen.augoperator(this, astnodes.Pow);
+            return new AugOperator(astnodes.Pow);
         }
         this.reset(mark);
         if ((literal = this.expect("//="))) {
-            return pegen.augoperator(this, astnodes.FloorDiv);
+            return new AugOperator(astnodes.FloorDiv);
         }
         this.reset(mark);
 
@@ -1270,7 +1271,7 @@ export class GeneratedParser extends Parser {
             (literal = this.expect("/")) &&
             (literal_1 = this.expect(","))
         ) {
-            return pegen.slash_with_default(this, a, b);
+            return new SlashWithDefault(a, b);
         }
         this.reset(mark);
         if (
@@ -1279,7 +1280,7 @@ export class GeneratedParser extends Parser {
             (literal = this.expect("/")) &&
             this.positive_lookahead(this.expect, ")")
         ) {
-            return pegen.slash_with_default(this, a, b);
+            return new SlashWithDefault(a, b);
         }
         this.reset(mark);
 
@@ -1297,7 +1298,7 @@ export class GeneratedParser extends Parser {
             (b = this._loop0_66()) &&
             ((c = this.kwds()), 1)
         ) {
-            return pegen.star_etc(this, a, b, c);
+            return new StarEtc(a, b, c);
         }
         this.reset(mark);
         if (
@@ -1306,11 +1307,11 @@ export class GeneratedParser extends Parser {
             (b = this._loop1_67()) &&
             ((c = this.kwds()), 1)
         ) {
-            return pegen.star_etc(this, null, b, c);
+            return new StarEtc(null, b, c);
         }
         this.reset(mark);
         if ((a = this.kwds())) {
-            return pegen.star_etc(this, null, null, a);
+            return new StarEtc(null, null, a);
         }
         this.reset(mark);
         if ((invalid_star_etc = this.invalid_star_etc())) {
@@ -1787,7 +1788,7 @@ export class GeneratedParser extends Parser {
             (literal = this.expect("/")) &&
             (literal_1 = this.expect(","))
         ) {
-            return pegen.slash_with_default(this, a, b);
+            return new SlashWithDefault(a, b);
         }
         this.reset(mark);
         if (
@@ -1796,7 +1797,7 @@ export class GeneratedParser extends Parser {
             (literal = this.expect("/")) &&
             this.positive_lookahead(this.expect, ":")
         ) {
-            return pegen.slash_with_default(this, a, b);
+            return new SlashWithDefault(a, b);
         }
         this.reset(mark);
 
@@ -1814,7 +1815,7 @@ export class GeneratedParser extends Parser {
             (b = this._loop0_86()) &&
             ((c = this.lambda_kwds()), 1)
         ) {
-            return pegen.star_etc(this, a, b, c);
+            return new StarEtc(a, b, c);
         }
         this.reset(mark);
         if (
@@ -1823,11 +1824,11 @@ export class GeneratedParser extends Parser {
             (b = this._loop1_87()) &&
             ((c = this.lambda_kwds()), 1)
         ) {
-            return pegen.star_etc(this, null, b, c);
+            return new StarEtc(null, b, c);
         }
         this.reset(mark);
         if ((a = this.lambda_kwds())) {
-            return pegen.star_etc(this, null, null, a);
+            return new StarEtc(null, null, a);
         }
         this.reset(mark);
         if ((invalid_lambda_star_etc = this.invalid_lambda_star_etc())) {
@@ -2057,7 +2058,7 @@ export class GeneratedParser extends Parser {
         let a, literal;
         const mark = this.mark();
         if ((literal = this.expect("==")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.Eq, a);
+            return new CmpopExprPair(astnodes.Eq, a);
         }
         this.reset(mark);
 
@@ -2070,7 +2071,7 @@ export class GeneratedParser extends Parser {
         let a, tok;
         const mark = this.mark();
         if ((tok = this.expect("!=")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.NotEq, a);
+            return new CmpopExprPair(astnodes.NotEq, a);
         }
         this.reset(mark);
 
@@ -2083,7 +2084,7 @@ export class GeneratedParser extends Parser {
         let a, literal;
         const mark = this.mark();
         if ((literal = this.expect("<=")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.LtE, a);
+            return new CmpopExprPair(astnodes.LtE, a);
         }
         this.reset(mark);
 
@@ -2096,7 +2097,7 @@ export class GeneratedParser extends Parser {
         let a, literal;
         const mark = this.mark();
         if ((literal = this.expect("<")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.Lt, a);
+            return new CmpopExprPair(astnodes.Lt, a);
         }
         this.reset(mark);
 
@@ -2109,7 +2110,7 @@ export class GeneratedParser extends Parser {
         let a, literal;
         const mark = this.mark();
         if ((literal = this.expect(">=")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.GtE, a);
+            return new CmpopExprPair(astnodes.GtE, a);
         }
         this.reset(mark);
 
@@ -2122,7 +2123,7 @@ export class GeneratedParser extends Parser {
         let a, literal;
         const mark = this.mark();
         if ((literal = this.expect(">")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.Gt, a);
+            return new CmpopExprPair(astnodes.Gt, a);
         }
         this.reset(mark);
 
@@ -2135,7 +2136,7 @@ export class GeneratedParser extends Parser {
         let a, keyword, keyword_1;
         const mark = this.mark();
         if ((keyword = this.expect("not")) && (keyword_1 = this.expect("in")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.NotIn, a);
+            return new CmpopExprPair(astnodes.NotIn, a);
         }
         this.reset(mark);
 
@@ -2148,7 +2149,7 @@ export class GeneratedParser extends Parser {
         let a, keyword;
         const mark = this.mark();
         if ((keyword = this.expect("in")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.In, a);
+            return new CmpopExprPair(astnodes.In, a);
         }
         this.reset(mark);
 
@@ -2161,7 +2162,7 @@ export class GeneratedParser extends Parser {
         let a, keyword, keyword_1;
         const mark = this.mark();
         if ((keyword = this.expect("is")) && (keyword_1 = this.expect("not")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.IsNot, a);
+            return new CmpopExprPair(astnodes.IsNot, a);
         }
         this.reset(mark);
 
@@ -2174,7 +2175,7 @@ export class GeneratedParser extends Parser {
         let a, keyword;
         const mark = this.mark();
         if ((keyword = this.expect("is")) && (a = this.bitwise_or())) {
-            return pegen.cmpop_expr_pair(this, astnodes.Is, a);
+            return new CmpopExprPair(astnodes.Is, a);
         }
         this.reset(mark);
 
@@ -2742,7 +2743,7 @@ export class GeneratedParser extends Parser {
         let a, kvpair, literal;
         const mark = this.mark();
         if ((literal = this.expect("**")) && (a = this.bitwise_or())) {
-            return pegen.key_value_pair(this, null, a);
+            return new KeyValuePair(null, a);
         }
         this.reset(mark);
         if ((kvpair = this.kvpair())) {
@@ -2759,7 +2760,7 @@ export class GeneratedParser extends Parser {
         let a, b, literal;
         const mark = this.mark();
         if ((a = this.expression()) && (literal = this.expect(":")) && (b = this.expression())) {
-            return pegen.key_value_pair(this, a, b);
+            return new KeyValuePair(a, b);
         }
         this.reset(mark);
 

--- a/src/parser/pegen.ts
+++ b/src/parser/pegen.ts
@@ -1638,10 +1638,6 @@ export function map_names_to_ids(p: Parser, seq: Name[]) {
 //     return new_seq;
 // }
 
-export function cmpop_expr_pair(p: Parser, cmpop: cmpop, expr: expr) {
-    return new CmpopExprPair(cmpop, expr);
-}
-
 // /* Constructs a CmpopExprPair */
 // CmpopExprPair *
 // _PyPegen_cmpop_expr_pair(Parser *p, cmpop_ty cmpop, expr_ty expr)
@@ -1819,10 +1815,6 @@ export function set_expr_context(p: Parser, e: expr, ctx: expr_context): expr {
 //     return new;
 // }
 
-export function key_value_pair(p: Parser, key: expr, value: expr) {
-    return new KeyValuePair(key, value);
-}
-
 // /* Constructs a KeyValuePair that is used when parsing a dict's key value pairs */
 // KeyValuePair *
 // _PyPegen_key_value_pair(Parser *p, expr_ty key, expr_ty value)
@@ -1914,10 +1906,6 @@ export function name_default_pair(p: Parser, arg: arg, value: expr, tc: TokenInf
 //     a->names_with_defaults = names_with_defaults;
 //     return a;
 // }
-
-export function star_etc(p: Parser, vararg: arg, kwonlyargs: NameDefaultPair[], kwarg: arg) {
-    return new StarEtc(vararg, kwonlyargs, kwarg);
-}
 
 // /* Constructs a StarEtc */
 // StarEtc *
@@ -2225,10 +2213,6 @@ export function empty_arguments(p: Parser) {
 //     return _Py_arguments(posonlyargs, posargs, NULL, kwonlyargs, kwdefaults, NULL, kwdefaults,
 //                          p->arena);
 // }
-
-export function augoperator(p: Parser, kind: operator) {
-    return new AugOperator(kind);
-}
 
 // /* Encapsulates the value of an operator_ty into an AugOperator struct */
 // AugOperator *

--- a/tools/gen_parser/skulpt_parser_genarator.py
+++ b/tools/gen_parser/skulpt_parser_genarator.py
@@ -43,13 +43,12 @@ MODULE_PREFIX = """\
 // @ts-nocheck
 
 import type {{ mod, expr, stmt, operator, alias, withitem, excepthandler, arguments_, arg, comprehension, Name, Call, FunctionDef, AsyncFunctionDef, Starred }} from "../ast/astnodes.ts";
-import type {{ StartRule, CmpopExprPair, KeyValuePair, NameDefaultPair, SlashWithDefault, StarEtc, AugOperator }} from "./pegen_types.ts";
 import type {{ Tokenizer }} from "../tokenize/Tokenizer.ts";
 import type {{ TokenInfo }} from "../tokenize/tokenize.ts";
 import * as astnodes from "../ast/astnodes.ts";
 import {{ pyNone, pyTrue, pyFalse, pyEllipsis }} from "../ast/constants.ts";
+import {{ StartRule, CmpopExprPair, KeyValuePair, KeywordToken, KeywordOrStarred, NameDefaultPair, SlashWithDefault, StarEtc, AugOperator }} from "./pegen_types.ts";
 import {{ pegen }} from "./pegen_proxy.ts";
-import {{ KeywordToken, KeywordOrStarred }} from "./pegen_types.ts";
 import {{ FILE_INPUT, SINGLE_INPUT, EVAL_INPUT, FUNC_TYPE_INPUT, FSTRING_INPUT }} from "./pegen_types.ts";
 
 import {{ memoize, memoizeLeftRec, logger, Parser}} from "./parser.ts";

--- a/tools/patch/grammar.patch
+++ b/tools/patch/grammar.patch
@@ -1,5 +1,5 @@
 diff --git a/Grammar/python.gram b/Grammar/python.gram
-index 64e205e7fd..99182cfaca 100644
+index 64e205e7fd..091ca0b65c 100644
 --- a/Grammar/python.gram
 +++ b/Grammar/python.gram
 @@ -2,7 +2,7 @@
@@ -141,19 +141,19 @@ index 64e205e7fd..99182cfaca 100644
 -del_stmt[stmt_ty]:
 -    | 'del' a=del_targets &(';' | NEWLINE) { _Py_Delete(a, EXTRA) }
 +augassign[AugOperator]:
-+    | '+=' { pegen.augoperator(this, astnodes.Add) }
-+    | '-=' { pegen.augoperator(this, astnodes.Sub) }
-+    | '*=' { pegen.augoperator(this, astnodes.Mult) }
-+    | '@=' { CHECK_VERSION(5, "The '@' operator is", pegen.augoperator(this, astnodes.MatMult)) }
-+    | '/=' { pegen.augoperator(this, astnodes.Div) }
-+    | '%=' { pegen.augoperator(this, astnodes.Mod) }
-+    | '&=' { pegen.augoperator(this, astnodes.BitAnd) }
-+    | '|=' { pegen.augoperator(this, astnodes.BitOr) }
-+    | '^=' { pegen.augoperator(this, astnodes.BitXor) }
-+    | '<<=' { pegen.augoperator(this, astnodes.LShift) }
-+    | '>>=' { pegen.augoperator(this, astnodes.RShift) }
-+    | '**=' { pegen.augoperator(this, astnodes.Pow) }
-+    | '//=' { pegen.augoperator(this, astnodes.FloorDiv) }
++    | '+=' { new AugOperator(astnodes.Add) }
++    | '-=' { new AugOperator(astnodes.Sub) }
++    | '*=' { new AugOperator(astnodes.Mult) }
++    | '@=' { CHECK_VERSION(5, "The '@' operator is", new AugOperator(astnodes.MatMult)) }
++    | '/=' { new AugOperator(astnodes.Div) }
++    | '%=' { new AugOperator(astnodes.Mod) }
++    | '&=' { new AugOperator(astnodes.BitAnd) }
++    | '|=' { new AugOperator(astnodes.BitOr) }
++    | '^=' { new AugOperator(astnodes.BitXor) }
++    | '<<=' { new AugOperator(astnodes.LShift) }
++    | '>>=' { new AugOperator(astnodes.RShift) }
++    | '**=' { new AugOperator(astnodes.Pow) }
++    | '//=' { new AugOperator(astnodes.FloorDiv) }
 +
 +global_stmt[stmt]: 'global' a=','.NAME+ {
 +    new astnodes.Global(CHECK(pegen.map_names_to_ids(this, a)), ...EXTRA) }
@@ -358,19 +358,19 @@ index 64e205e7fd..99182cfaca 100644
 -    | a=param_no_default* b=param_with_default+ '/' ',' { _PyPegen_slash_with_default(p, a, b) }
 -    | a=param_no_default* b=param_with_default+ '/' &')' { _PyPegen_slash_with_default(p, a, b) }
 +slash_with_default[SlashWithDefault]:
-+    | a=param_no_default* b=param_with_default+ '/' ',' { pegen.slash_with_default(this, a, b) }
-+    | a=param_no_default* b=param_with_default+ '/' &')' { pegen.slash_with_default(this, a, b) }
++    | a=param_no_default* b=param_with_default+ '/' ',' { new SlashWithDefault(a, b) }
++    | a=param_no_default* b=param_with_default+ '/' &')' { new SlashWithDefault(a, b) }
  
 -star_etc[StarEtc*]:
 +star_etc[StarEtc]:
      | '*' a=param_no_default b=param_maybe_default* c=[kwds] {
 -        _PyPegen_star_etc(p, a, b, c) }
-+        pegen.star_etc(this, a, b, c) }
++        new StarEtc(a, b, c) }
      | '*' ',' b=param_maybe_default+ c=[kwds] {
 -        _PyPegen_star_etc(p, NULL, b, c) }
 -    | a=kwds { _PyPegen_star_etc(p, NULL, NULL, a) }
-+        pegen.star_etc(this, null, b, c) }
-+    | a=kwds { pegen.star_etc(this, null, null, a) }
++        new StarEtc(null, b, c) }
++    | a=kwds { new StarEtc(null, null, a) }
      | invalid_star_etc
  
 -kwds[arg_ty]: '**' a=param_no_default { a }
@@ -523,19 +523,19 @@ index 64e205e7fd..99182cfaca 100644
 -    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' ',' { _PyPegen_slash_with_default(p, a, b) }
 -    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' &':' { _PyPegen_slash_with_default(p, a, b) }
 +lambda_slash_with_default[SlashWithDefault]:
-+    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' ',' { pegen.slash_with_default(this, a, b) }
-+    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' &':' { pegen.slash_with_default(this, a, b) }
++    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' ',' { new SlashWithDefault(a, b) }
++    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' &':' { new SlashWithDefault(a, b) }
  
 -lambda_star_etc[StarEtc*]:
 +lambda_star_etc[StarEtc]:
      | '*' a=lambda_param_no_default b=lambda_param_maybe_default* c=[lambda_kwds] {
 -        _PyPegen_star_etc(p, a, b, c) }
-+        pegen.star_etc(this, a, b, c) }
++        new StarEtc(a, b, c) }
      | '*' ',' b=lambda_param_maybe_default+ c=[lambda_kwds] {
 -        _PyPegen_star_etc(p, NULL, b, c) }
 -    | a=lambda_kwds { _PyPegen_star_etc(p, NULL, NULL, a) }
-+        pegen.star_etc(this, null, b, c) }
-+    | a=lambda_kwds { pegen.star_etc(this, null, null, a) }
++        new StarEtc(null, b, c) }
++    | a=lambda_kwds { new StarEtc(null, null, a) }
      | invalid_lambda_star_etc
  
 -lambda_kwds[arg_ty]: '**' a=lambda_param_no_default { a }
@@ -617,17 +617,17 @@ index 64e205e7fd..99182cfaca 100644
 -
 -bitwise_or[expr_ty]:
 -    | a=bitwise_or '|' b=bitwise_xor { _Py_BinOp(a, BitOr, b, EXTRA) }
-+eq_bitwise_or[CmpopExprPair]: '==' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.Eq, a) }
++eq_bitwise_or[CmpopExprPair]: '==' a=bitwise_or { new CmpopExprPair(astnodes.Eq, a) }
 +noteq_bitwise_or[CmpopExprPair]:
-+    | (tok='!=' { pegen.check_barry_as_flufl(this, tok) ? null : tok}) a=bitwise_or {pegen.cmpop_expr_pair(this, astnodes.NotEq, a) }
-+lte_bitwise_or[CmpopExprPair]: '<=' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.LtE, a) }
-+lt_bitwise_or[CmpopExprPair]: '<' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.Lt, a) }
-+gte_bitwise_or[CmpopExprPair]: '>=' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.GtE, a) }
-+gt_bitwise_or[CmpopExprPair]: '>' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.Gt, a) }
-+notin_bitwise_or[CmpopExprPair]: 'not' 'in' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.NotIn, a) }
-+in_bitwise_or[CmpopExprPair]: 'in' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.In, a) }
-+isnot_bitwise_or[CmpopExprPair]: 'is' 'not' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.IsNot, a) }
-+is_bitwise_or[CmpopExprPair]: 'is' a=bitwise_or { pegen.cmpop_expr_pair(this, astnodes.Is, a) }
++    | (tok='!=' { pegen.check_barry_as_flufl(this, tok) ? null : tok}) a=bitwise_or {new CmpopExprPair(astnodes.NotEq, a) }
++lte_bitwise_or[CmpopExprPair]: '<=' a=bitwise_or { new CmpopExprPair(astnodes.LtE, a) }
++lt_bitwise_or[CmpopExprPair]: '<' a=bitwise_or { new CmpopExprPair(astnodes.Lt, a) }
++gte_bitwise_or[CmpopExprPair]: '>=' a=bitwise_or { new CmpopExprPair(astnodes.GtE, a) }
++gt_bitwise_or[CmpopExprPair]: '>' a=bitwise_or { new CmpopExprPair(astnodes.Gt, a) }
++notin_bitwise_or[CmpopExprPair]: 'not' 'in' a=bitwise_or { new CmpopExprPair(astnodes.NotIn, a) }
++in_bitwise_or[CmpopExprPair]: 'in' a=bitwise_or { new CmpopExprPair(astnodes.In, a) }
++isnot_bitwise_or[CmpopExprPair]: 'is' 'not' a=bitwise_or { new CmpopExprPair(astnodes.IsNot, a) }
++is_bitwise_or[CmpopExprPair]: 'is' a=bitwise_or { new CmpopExprPair(astnodes.Is, a) }
 +
 +bitwise_or[expr]:
 +    | a=bitwise_or '|' b=bitwise_xor { new astnodes.BinOp(a, astnodes.BitOr, b, ...EXTRA) }
@@ -786,11 +786,11 @@ index 64e205e7fd..99182cfaca 100644
 -    | '**' a=bitwise_or { _PyPegen_key_value_pair(p, NULL, a) }
 +double_starred_kvpairs[any]: a=','.double_starred_kvpair+ [','] { a }
 +double_starred_kvpair[KeyValuePair]:
-+    | '**' a=bitwise_or { pegen.key_value_pair(this, null, a) }
++    | '**' a=bitwise_or { new KeyValuePair(null, a) }
      | kvpair
 -kvpair[KeyValuePair*]: a=expression ':' b=expression { _PyPegen_key_value_pair(p, a, b) }
 -for_if_clauses[asdl_seq*]:
-+kvpair[KeyValuePair]: a=expression ':' b=expression { pegen.key_value_pair(this, a, b) }
++kvpair[KeyValuePair]: a=expression ':' b=expression { new KeyValuePair(a, b) }
 +for_if_clauses[any]:
      | for_if_clause+
 -for_if_clause[comprehension_ty]:


### PR DESCRIPTION
for some of these we don't need to go via pegen and seems worth inlining them

there's a couple that complain now when we turn on typechecking in the generated parser
e.g. KeyValuePair get's called with null