### PR TITLE
use enum for tokens

### DIFF
--- a/src/parser/generated_parser.ts
+++ b/src/parser/generated_parser.ts
@@ -35,7 +35,6 @@ import {
     AugOperator,
 } from "./pegen_types.ts";
 import { pegen } from "./pegen_proxy.ts";
-import { FILE_INPUT, SINGLE_INPUT, EVAL_INPUT, FUNC_TYPE_INPUT, FSTRING_INPUT } from "./pegen_types.ts";
 
 import { memoize, memoizeLeftRec, logger, Parser } from "./parser.ts";
 
@@ -58,7 +57,7 @@ export class GeneratedParser extends Parser {
     start_rule: StartRule;
     flags: number;
 
-    constructor(T: Tokenizer, start_rule: StartRule = FILE_INPUT, flags = 0) {
+    constructor(T: Tokenizer, start_rule: StartRule = StartRule.FILE_INPUT, flags = 0) {
         super(T);
         this.start_rule = start_rule;
         this.flags = flags; // unused
@@ -66,15 +65,15 @@ export class GeneratedParser extends Parser {
 
     parse(): mod | expr | null {
         switch (this.start_rule) {
-            case FILE_INPUT:
+            case StartRule.FILE_INPUT:
                 return this.file();
-            case SINGLE_INPUT:
+            case StartRule.SINGLE_INPUT:
                 return this.interactive();
-            case EVAL_INPUT:
+            case StartRule.EVAL_INPUT:
                 return this.eval();
-            case FUNC_TYPE_INPUT:
+            case StartRule.FUNC_TYPE_INPUT:
                 return this.func_type();
-            case FSTRING_INPUT:
+            case StartRule.FSTRING_INPUT:
                 return this.fstring();
             default:
                 return null;

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,17 +1,17 @@
 import { tokenizerFromFile, tokenizerFromString } from "../tokenize/mod.ts";
 import { GeneratedParser } from "./generated_parser.ts";
-import { EVAL_INPUT, FILE_INPUT, SINGLE_INPUT, StartRule } from "./pegen_types.ts";
+import { StartRule } from "./pegen_types.ts";
 
 type ModeStr = "exec" | "eval" | "single";
 
 function modeStrToStartRule(mode: ModeStr): StartRule {
     switch (mode) {
         case "exec":
-            return FILE_INPUT;
+            return StartRule.FILE_INPUT;
         case "eval":
-            return EVAL_INPUT;
+            return StartRule.EVAL_INPUT;
         case "single":
-            return SINGLE_INPUT;
+            return StartRule.SINGLE_INPUT;
         default:
             throw new Error(`bad mode - got ${mode} - use 'exec', 'eval' or 'single'`);
     }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,7 +1,6 @@
-import { DEDENT, ENDMARKER, NAME, NEWLINE, NUMBER, OP, STRING, tok_name } from "../tokenize/token.ts";
+import { DEDENT, ENDMARKER, NAME, NEWLINE, NUMBER, OP, STRING, tokens } from "../tokenize/token.ts";
 import { exact_token_types } from "../tokenize/Tokenizer.ts";
 import type { Tokenizer } from "../tokenize/Tokenizer.ts";
-import { tokens } from "../tokenize/token.ts";
 import { pySyntaxError } from "../tokenize/tokenize.ts";
 import type { TokenInfo } from "../tokenize/tokenize.ts";
 import { Name, Load, TypeIgnore, Constant } from "../ast/astnodes.ts";
@@ -181,7 +180,7 @@ export class Parser {
             }
         }
         if (type in tokens) {
-            if (tok.type === tokens[type]) {
+            if (tok.type === tokens[type as keyof typeof tokens]) {
                 return this.getnext();
             }
         }

--- a/src/parser/pegen_types.ts
+++ b/src/parser/pegen_types.ts
@@ -84,15 +84,14 @@ export class KeywordToken {
 }
 
 /* These definitions must match corresponding definitions in graminit.h. */
-export const SINGLE_INPUT = 256;
-export const FILE_INPUT = 257;
-export const EVAL_INPUT = 258;
-export const FUNC_TYPE_INPUT = 345;
-
-/* This doesn't need to match anything */
-export const FSTRING_INPUT = 800;
-
-export type StartRule = 256 | 257 | 258 | 345 | 800;
+export enum StartRule {
+    SINGLE_INPUT = 256,
+    FILE_INPUT,
+    EVAL_INPUT,
+    FUNC_TYPE_INPUT = 345,
+    /* This doesn't need to match anything */
+    FSTRING_INPUT = 800,
+}
 
 export function EXTRA_EXPR(head: expr, tail?: expr): Attrs {
     tail ??= head;

--- a/src/parser/verbose_parser.ts
+++ b/src/parser/verbose_parser.ts
@@ -1,4 +1,4 @@
-import { tok_name } from "../tokenize/token.ts";
+import { tokens } from "../tokenize/token.ts";
 import type { Tokenizer } from "../tokenize/Tokenizer.ts";
 import type { TokenInfo } from "../tokenize/tokenize.ts";
 import { Parser as BaseParser } from "./parser.ts";
@@ -144,7 +144,7 @@ export class VerboseParser extends BaseParser {
     }
     showpeek(): string {
         const tok = this.peek();
-        return `${tok.start[0]}.${tok.start[1]}: ${tok_name[tok.type]}:'${tok.string}'`;
+        return `${tok.start[0]}.${tok.start[1]}: ${tokens[tok.type]}:'${tok.string}'`;
     }
     _fill() {
         return "  ".repeat(this._level);

--- a/src/tokenize/token.ts
+++ b/src/tokenize/token.ts
@@ -1,74 +1,4 @@
-// we should auto generate this
-
-export const ENDMARKER = 0;
-export const NAME = 1;
-export const NUMBER = 2;
-export const STRING = 3;
-export const NEWLINE = 4;
-export const INDENT = 5;
-export const DEDENT = 6;
-export const LPAR = 7;
-export const RPAR = 8;
-export const LSQB = 9;
-export const RSQB = 10;
-export const COLON = 11;
-export const COMMA = 12;
-export const SEMI = 13;
-export const PLUS = 14;
-export const MINUS = 15;
-export const STAR = 16;
-export const SLASH = 17;
-export const VBAR = 18;
-export const AMPER = 19;
-export const LESS = 20;
-export const GREATER = 21;
-export const EQUAL = 22;
-export const DOT = 23;
-export const PERCENT = 24;
-export const LBRACE = 25;
-export const RBRACE = 26;
-export const EQEQUAL = 27;
-export const NOTEQUAL = 28;
-export const LESSEQUAL = 29;
-export const GREATEREQUAL = 30;
-export const TILDE = 31;
-export const CIRCUMFLEX = 32;
-export const LEFTSHIFT = 33;
-export const RIGHTSHIFT = 34;
-export const DOUBLESTAR = 35;
-export const PLUSEQUAL = 36;
-export const MINEQUAL = 37;
-export const STAREQUAL = 38;
-export const SLASHEQUAL = 39;
-export const PERCENTEQUAL = 40;
-export const AMPEREQUAL = 41;
-export const VBAREQUAL = 42;
-export const CIRCUMFLEXEQUAL = 43;
-export const LEFTSHIFTEQUAL = 44;
-export const RIGHTSHIFTEQUAL = 45;
-export const DOUBLESTAREQUAL = 46;
-export const DOUBLESLASH = 47;
-export const DOUBLESLASHEQUAL = 48;
-export const AT = 49;
-export const ATEQUAL = 50;
-export const RARROW = 51;
-export const ELLIPSIS = 52;
-export const COLONEQUAL = 53;
-export const OP = 54;
-export const AWAIT = 55;
-export const ASYNC = 56;
-export const TYPE_IGNORE = 57;
-export const TYPE_COMMENT = 58;
-// # These aren't used by the C tokenizer but are needed for tokenize.py
-export const ERRORTOKEN = 59;
-export const COMMENT = 60;
-export const NL = 61;
-export const ENCODING = 62;
-export const N_TOKENS = 63;
-// # Special definitions for cooperation with parser
-export const NT_OFFSET = 256;
-
-export const tokens: { [tok_name: string]: number } = {
+export enum tokens {
     ENDMARKER,
     NAME,
     NUMBER,
@@ -128,78 +58,73 @@ export const tokens: { [tok_name: string]: number } = {
     ASYNC,
     TYPE_IGNORE,
     TYPE_COMMENT,
-    // # These aren't used by the C tokenizer but are needed for tokenize.py
     ERRORTOKEN,
     COMMENT,
     NL,
     ENCODING,
     N_TOKENS,
-    // # Special definitions for cooperation with parser
-    NT_OFFSET,
+}
+
+export const ENDMARKER = tokens.ENDMARKER;
+export const NAME = tokens.NAME;
+export const NUMBER = tokens.NUMBER;
+export const STRING = tokens.STRING;
+export const NEWLINE = tokens.NEWLINE;
+export const INDENT = tokens.INDENT;
+export const DEDENT = tokens.DEDENT;
+export const DOT = tokens.DOT;
+export const ELLIPSIS = tokens.ELLIPSIS;
+export const OP = tokens.OP;
+export const ERRORTOKEN = tokens.ERRORTOKEN;
+export const COMMENT = tokens.COMMENT;
+export const NL = tokens.NL;
+
+export const EXACT_TOKEN_TYPES: { [token: string]: tokens } = {
+    "!=": tokens.NOTEQUAL,
+    "%": tokens.PERCENT,
+    "%=": tokens.PERCENTEQUAL,
+    "&": tokens.AMPER,
+    "&=": tokens.AMPEREQUAL,
+    "(": tokens.LPAR,
+    ")": tokens.RPAR,
+    "*": tokens.STAR,
+    "**": tokens.DOUBLESTAR,
+    "**=": tokens.DOUBLESTAREQUAL,
+    "*=": tokens.STAREQUAL,
+    "+": tokens.PLUS,
+    "+=": tokens.PLUSEQUAL,
+    ",": tokens.COMMA,
+    "-": tokens.MINUS,
+    "-=": tokens.MINEQUAL,
+    "->": tokens.RARROW,
+    ".": tokens.DOT,
+    "...": tokens.ELLIPSIS,
+    "/": tokens.SLASH,
+    "//": tokens.DOUBLESLASH,
+    "//=": tokens.DOUBLESLASHEQUAL,
+    "/=": tokens.SLASHEQUAL,
+    ":": tokens.COLON,
+    ":=": tokens.COLONEQUAL,
+    ";": tokens.SEMI,
+    "<": tokens.LESS,
+    "<<": tokens.LEFTSHIFT,
+    "<<=": tokens.LEFTSHIFTEQUAL,
+    "<=": tokens.LESSEQUAL,
+    "=": tokens.EQUAL,
+    "==": tokens.EQEQUAL,
+    ">": tokens.GREATER,
+    ">=": tokens.GREATEREQUAL,
+    ">>": tokens.RIGHTSHIFT,
+    ">>=": tokens.RIGHTSHIFTEQUAL,
+    "@": tokens.AT,
+    "@=": tokens.ATEQUAL,
+    "[": tokens.LSQB,
+    "]": tokens.RSQB,
+    "^": tokens.CIRCUMFLEX,
+    "^=": tokens.CIRCUMFLEXEQUAL,
+    "{": tokens.LBRACE,
+    "|": tokens.VBAR,
+    "|=": tokens.VBAREQUAL,
+    "}": tokens.RBRACE,
+    "~": tokens.TILDE,
 };
-
-Object.freeze(tokens);
-
-export const tok_name = Object.fromEntries(Object.entries(tokens).map(([key, val]) => [val, key]));
-
-export const EXACT_TOKEN_TYPES: { [token: string]: number } = {
-    "!=": NOTEQUAL,
-    "%": PERCENT,
-    "%=": PERCENTEQUAL,
-    "&": AMPER,
-    "&=": AMPEREQUAL,
-    "(": LPAR,
-    ")": RPAR,
-    "*": STAR,
-    "**": DOUBLESTAR,
-    "**=": DOUBLESTAREQUAL,
-    "*=": STAREQUAL,
-    "+": PLUS,
-    "+=": PLUSEQUAL,
-    ",": COMMA,
-    "-": MINUS,
-    "-=": MINEQUAL,
-    "->": RARROW,
-    ".": DOT,
-    "...": ELLIPSIS,
-    "/": SLASH,
-    "//": DOUBLESLASH,
-    "//=": DOUBLESLASHEQUAL,
-    "/=": SLASHEQUAL,
-    ":": COLON,
-    ":=": COLONEQUAL,
-    ";": SEMI,
-    "<": LESS,
-    "<<": LEFTSHIFT,
-    "<<=": LEFTSHIFTEQUAL,
-    "<=": LESSEQUAL,
-    "=": EQUAL,
-    "==": EQEQUAL,
-    ">": GREATER,
-    ">=": GREATEREQUAL,
-    ">>": RIGHTSHIFT,
-    ">>=": RIGHTSHIFTEQUAL,
-    "@": AT,
-    "@=": ATEQUAL,
-    "[": LSQB,
-    "]": RSQB,
-    "^": CIRCUMFLEX,
-    "^=": CIRCUMFLEXEQUAL,
-    "{": LBRACE,
-    "|": VBAR,
-    "|=": VBAREQUAL,
-    "}": RBRACE,
-    "~": TILDE,
-};
-
-export function ISTERMINAL(x: number): boolean {
-    return x < NT_OFFSET;
-}
-
-export function ISNONTERMINAL(x: number): boolean {
-    return x >= NT_OFFSET;
-}
-
-export function ISEOF(x: number): boolean {
-    return x == ENDMARKER;
-}

--- a/src/tokenize/tokenize.ts
+++ b/src/tokenize/tokenize.ts
@@ -1,7 +1,6 @@
 import { w } from "../util/unicode.ts";
 import { isIdentifier } from "../util/str_helpers.ts";
-import * as tokens from "./token.ts";
-import { EXACT_TOKEN_TYPES } from "./token.ts";
+import { tokens, EXACT_TOKEN_TYPES } from "./token.ts";
 
 type token = number;
 type position = [number, number];

--- a/tools/gen_parser/skulpt_parser_genarator.py
+++ b/tools/gen_parser/skulpt_parser_genarator.py
@@ -49,7 +49,6 @@ import * as astnodes from "../ast/astnodes.ts";
 import {{ pyNone, pyTrue, pyFalse, pyEllipsis }} from "../ast/constants.ts";
 import {{ StartRule, CmpopExprPair, KeyValuePair, KeywordToken, KeywordOrStarred, NameDefaultPair, SlashWithDefault, StarEtc, AugOperator }} from "./pegen_types.ts";
 import {{ pegen }} from "./pegen_proxy.ts";
-import {{ FILE_INPUT, SINGLE_INPUT, EVAL_INPUT, FUNC_TYPE_INPUT, FSTRING_INPUT }} from "./pegen_types.ts";
 
 import {{ memoize, memoizeLeftRec, logger, Parser}} from "./parser.ts";
 
@@ -295,7 +294,7 @@ export class GeneratedParser extends Parser {
     start_rule: StartRule;
     flags: number;
 
-    constructor(T: Tokenizer, start_rule: StartRule=FILE_INPUT, flags=0) {
+    constructor(T: Tokenizer, start_rule: StartRule=StartRule.FILE_INPUT, flags=0) {
         super(T);
         this.start_rule=start_rule;
         this.flags=flags; // unused
@@ -303,15 +302,15 @@ export class GeneratedParser extends Parser {
 
     parse(): mod | expr | null {
         switch (this.start_rule) {
-            case FILE_INPUT:
+            case StartRule.FILE_INPUT:
                 return this.file();
-            case SINGLE_INPUT:
+            case StartRule.SINGLE_INPUT:
                 return this.interactive();
-            case EVAL_INPUT:
+            case StartRule.EVAL_INPUT:
                 return this.eval();
-            case FUNC_TYPE_INPUT:
+            case StartRule.FUNC_TYPE_INPUT:
                 return this.func_type();
-            case FSTRING_INPUT:
+            case StartRule.FSTRING_INPUT:
                 return this.fstring();
             default:
                 return null;


### PR DESCRIPTION
I think it simplifies the implementation somewhat

allows reverse lookup which we use in the verbose parser.

