### PR TITLE
filename

### DIFF
--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -17,12 +17,22 @@ function modeStrToStartRule(mode: ModeStr): StartRule {
     }
 }
 
-export function runParserFromString(text: string, mode: ModeStr = "exec") {
-    const parser = new GeneratedParser(tokenizerFromString(text), modeStrToStartRule(mode));
-    return parser.parse();
+export function parserFromString(text: string, mode: ModeStr = "exec", filename = "<string>") {
+    const parser = new GeneratedParser(tokenizerFromString(text, filename), modeStrToStartRule(mode));
+    parser.filename = filename;
+    return parser;
+}
+
+export function runParserFromString(text: string, mode: ModeStr = "exec", filename = "<string>") {
+    return parserFromString(text, mode, filename).parse();
+}
+
+export function parserFromFile(filename: string, mode: ModeStr = "exec") {
+    const parser = new GeneratedParser(tokenizerFromFile(filename), modeStrToStartRule(mode));
+    parser.filename = filename;
+    return parser;
 }
 
 export function runParserFromFile(filename: string, mode: ModeStr = "exec") {
-    const parser = new GeneratedParser(tokenizerFromFile(filename), modeStrToStartRule(mode));
-    return parser.parse();
+    return parserFromFile(filename, mode).parse();
 }

--- a/src/parser/parse_string.ts
+++ b/src/parser/parse_string.ts
@@ -176,21 +176,15 @@ function fstring_compile_expr(p: Parser, str: string, expr_start: number, expr_e
     // the f-string expression. This consequently gets parsed as a group (see the
     // group rule in python.gram).
     s = "(" + s + ")";
-    try {
-        const tokenizer = tokenizerFromString(s);
-        tokenizer.starting_lineno = lines - 1;
-        tokenizer.starting_col_offset = cols - 1;
-        /**@todo adjust the filename here */
-        const p2 = new GeneratedParser(tokenizer, StartRule.FSTRING_INPUT);
-        return p2.parse();
-    } catch (e) {
-        // if (e.traceback && e.traceback[0]) {
-        //     let tb = e.traceback[0];
-        //     tb.lineno = (tb.lineno || 1) - 1 + LINENO(n);
-        //     tb.filename = c.c_filename;
-        // }
-        throw e;
-    }
+
+    const tokenizer = tokenizerFromString(s, p.filename);
+    tokenizer.starting_lineno = lines - 1;
+    tokenizer.starting_col_offset = cols - 1;
+    const p2 = new GeneratedParser(tokenizer, StartRule.FSTRING_INPUT);
+    p2.filename = p.filename;
+
+    // this might throw - lineno and offsets already adjusted
+    return p2.parse();
 }
 
 function fstring_find_expr(

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,5 +1,16 @@
 // deno-lint-ignore-file camelcase
-import { DEDENT, ENDMARKER, INDENT, NAME, NEWLINE, NUMBER, OP, STRING, EXACT_TOKEN_TYPES, tokens } from "../tokenize/token.ts";
+import {
+    DEDENT,
+    ENDMARKER,
+    INDENT,
+    NAME,
+    NEWLINE,
+    NUMBER,
+    OP,
+    STRING,
+    EXACT_TOKEN_TYPES,
+    tokens,
+} from "../tokenize/token.ts";
 import type { Tokenizer } from "../tokenize/Tokenizer.ts";
 import type { TokenInfo } from "../tokenize/tokenize.ts";
 import { Name, Load, TypeIgnore, Constant, expr } from "../ast/astnodes.ts";
@@ -105,6 +116,7 @@ export class Parser {
     getnext: () => TokenInfo;
     diagnose: () => TokenInfo;
     _tokens: TokenInfo[];
+    filename: string;
 
     type_ignore_comments: TypeIgnore[] = [];
 
@@ -117,6 +129,7 @@ export class Parser {
         this.getnext = this._tokenizer.getnext.bind(this._tokenizer);
         this.diagnose = this._tokenizer.diagnose.bind(this._tokenizer);
         this._tokens = this._tokenizer._tokens;
+        this.filename = "<unknown>";
     }
 
     extra(start: number): [number, number, number, number] {
@@ -166,7 +179,7 @@ export class Parser {
             }
             i--;
         }
-        throw new errType(msg, ["<file>", lineno, offset, errLine]);
+        throw new errType(msg, [this.filename, lineno, offset, errLine]);
     }
 
     raise_error_invalid_target(type: TARGETS_TYPE, e: expr | null): never {

--- a/src/tokenize/mod.ts
+++ b/src/tokenize/mod.ts
@@ -2,10 +2,10 @@ import { readFile, readString } from "./readline.ts";
 import { tokenize } from "./tokenize.ts";
 import { Tokenizer } from "./Tokenizer.ts";
 
-export function tokenizerFromString(text: string) {
-    return new Tokenizer(tokenize(readString(text)));
+export function tokenizerFromString(text: string, filename = "<string>") {
+    return new Tokenizer(tokenize(readString(text), filename));
 }
 
 export function tokenizerFromFile(filename: string) {
-    return new Tokenizer(tokenize(readFile(filename)));
+    return new Tokenizer(tokenize(readFile(filename), filename));
 }

--- a/src/tokenize/tokenize.ts
+++ b/src/tokenize/tokenize.ts
@@ -173,22 +173,23 @@ const PseudoToken = Whitespace + group(PseudoExtras, Number_, Funny, ContStr, Na
 
 const PseudoTokenRegexp = new RegExp(PseudoToken);
 
+const UnknownFile = "<unknown>";
+
 /** In python this should actually yield bytes */
-export function tokenize(readline: IterableIterator<string>): IterableIterator<TokenInfo> {
-    return _tokenize(readline);
+export function tokenize(readline: IterableIterator<string>, filename = UnknownFile): IterableIterator<TokenInfo> {
+    return _tokenize(readline, filename);
 }
 
 /** In python this the same api i.e. we yield strings except the readline is callable rather than a generator - see tokenize.py */
-export function generate_tokens(readline: IterableIterator<string>): IterableIterator<TokenInfo> {
-    return _tokenize(readline);
+export function generate_tokens(
+    readline: IterableIterator<string>,
+    filename = UnknownFile
+): IterableIterator<TokenInfo> {
+    return _tokenize(readline, filename);
 }
 
 /** We largely ignore the encoding here. In python the readline might be a bytes iterator */
-function* _tokenize(
-    readline: IterableIterator<string>,
-    encoding?: string | null,
-    filename = "<tokenize>"
-): IterableIterator<TokenInfo> {
+function* _tokenize(readline: IterableIterator<string>, filename = UnknownFile): IterableIterator<TokenInfo> {
     const numchars = "0123456789";
     let lnum = 0,
         parenlev = 0,
@@ -204,14 +205,14 @@ function* _tokenize(
         pseudomatch: RegExpExecArray | null;
 
     // since we don't do this with bytes this is not used
-    if (encoding != null) {
-        if (encoding === "utf-8-sig") {
-            // BOM will already have been stripped.
-            encoding = "utf-8";
-        }
+    // if (encoding != null) {
+    //     if (encoding === "utf-8-sig") {
+    //         // BOM will already have been stripped.
+    //         encoding = "utf-8";
+    //     }
 
-        yield new TokenInfo(tokens.ENCODING, encoding, [0, 0], [0, 0], "");
-    }
+    //     yield new TokenInfo(tokens.ENCODING, encoding, [0, 0], [0, 0], "");
+    // }
 
     let lastline = "";
     let line = "";


### PR DESCRIPTION
close #67 

filename only seems necessary for us for errors.

So it needs to be passed to `tokenize` and to the parser.

All the helper functions can take a filename