### PR TITLE
improve performance of cache

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,14 @@
     "trailingComma": "es5",
     "tabWidth": 4,
     "printWidth": 119,
-    "proseWrap": "never"
+    "proseWrap": "never",
+    "overrides": [
+        {
+            "files": "*.md",
+            "options": {
+                "proseWrap": "preserve",
+                "tabWidth": 2
+            }
+        }
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -1,25 +1,50 @@
-Experiments with python 3.9 pegen parser for Skulpt
+## Experiments with python 3.9 pegen parser for Skulpt
 
-Requirements
+### Requirements
 
--   [Deno](https://deno.land/manual/getting_started/installation)
--   [Velociraptor](https://velociraptor.run/docs/installation/)
--   [Pre-commit](https://pre-commit.com/#install)
+- [Deno](https://deno.land/manual/getting_started/installation)
+- [Velociraptor](https://velociraptor.run/docs/installation/)
+- [Pre-commit](https://pre-commit.com/#install) - `pre-commit install` must be executed for this plugin to have an effect
 
-Scripts
+### Scripts
 
--   `vr build` - bundles the typescript files into a javascript bundle
--   `vr bundle` - an alternative to build - uses deno bundle - no minified version
--   `vr format` - runs the precommit hooks for all files
+- `vr build`
+  _bundles the typescript files into a javascript bundle)_
+- `vr bundle`
+  _an alternative to build - uses deno bundle - no minified version_
+- `vr format`
+  _runs the precommit hooks for all files_
+- `vr gen_parser [-v --verbose --verbosity]=1|2`
+  _generates the javascript parser. Use `--verbose|-v|--verbosity` to generate a verbose parser._
+- `vr gen_asdl`
+  _generates the javascript astnodes_
+- `vr gen_ast`
+  _regenerates the ast for the run-test files from python and dumps the ast in .ast files_
+- `vr gen_gramar_patch`
+  _run this after you manually changed the gramar file to store your changes_
+- `vr apply_gramar_patch`
+  _run this patch the gramar with the changes stored in the patch_
+- `vr parse <filename|number> [--nc --no_comapre] [--mode=exec]`
+  _parses a python file and logs the generated ast vs the python ast_
+- `vr parse_str <code string> [--nc --no_comapre] [--mode=exec]`
+  _parses a python file and logs the generated ast vs the python ast_
+- `vr test <shortname> [-f --fail-fast] [-v]`
+  _run a test - shortnames: `pypeg`, `parse`, `dump`_
 
--   `vr gen_parser [-v --verbose --verbosity]=1|2` - generates the javascript parser. Use --verbose|-v|--verbosity to generate a verbose parser.
--   `vr gen_asdl` - generates the javascript astnodes
--   `vr gen_ast` - regenerates the ast for the run-test files from python and dumps the ast in .ast files
+### Debugging/Pofiling
 
--   `vr gen_gramar_patch` - run this after you manually changed the gramar file to store your changes
--   `vr apply_gramar_patch` - run this patch the gramar with the changes stored in the patch
+See Deno docs on [the subject](https://deno.land/manual/getting_started/debugging_your_code).
 
--   `vr parse <filename|number> --no_comapre --mode=exec` - parses a python file and logs the generated ast vs the python ast
--   `vr parse_str <code string> --no_comapre --mode=exec` - parses a python file and logs the generated ast vs the python ast
+```sh
+# example script execution for inspection use the [--inspect-brk] flag
+deno run -A --inspect-brk scripts/parse.ts tmp.txt
+```
 
--   `vr test <shortname> [-f --fail-fast] [-v]` - run a test - shortnames: pypeg, parse, dump
+Open `chrome://inspect` and click `Inspect` below `Target`:
+
+<img width="240" alt="inspect" src="https://deno.land/x/deno@v1.11.3/docs/images/debugger1.jpg">
+
+- This will open chrome devtools.
+- The execution of the script will be paused.
+- Run the profiler or add break points to the source and resume the execution
+  _(Click `pretty-print` in source files to display times from profiling)_

--- a/README.md
+++ b/README.md
@@ -9,27 +9,27 @@
 ### Scripts
 
 - `vr build`
-  ⋅⋅⋅ _bundles the typescript files into a javascript bundle)_
+  - _bundles the typescript files into a javascript bundle)_
 - `vr bundle`
-  _an alternative to build - uses deno bundle - no minified version_
+  - _an alternative to build - uses deno bundle - no minified version_
 - `vr format`
-  _runs the precommit hooks for all files_
+  - _runs the precommit hooks for all files_
 - `vr gen_parser [-v --verbose --verbosity]=1|2`
-  _generates the javascript parser. Use `--verbose|-v|--verbosity` to generate a verbose parser._
+  - _generates the javascript parser. Use `--verbose|-v|--verbosity` to generate a verbose parser._
 - `vr gen_asdl`
-  _generates the javascript astnodes_
+  - _generates the javascript astnodes_
 - `vr gen_ast`
-  _regenerates the ast for the run-test files from python and dumps the ast in .ast files_
+  - _regenerates the ast for the run-test files from python and dumps the ast in .ast files_
 - `vr gen_gramar_patch`
-  _run this after you manually changed the gramar file to store your changes_
+  - _run this after you manually changed the gramar file to store your changes_
 - `vr apply_gramar_patch`
-  _run this patch the gramar with the changes stored in the patch_
+  - _run this patch the gramar with the changes stored in the patch_
 - `vr parse <filename|number> [--nc --no_comapre] [--mode=exec]`
-  _parses a python file and logs the generated ast vs the python ast_
+  - _parses a python file and logs the generated ast vs the python ast_
 - `vr parse_str <code string> [--nc --no_comapre] [--mode=exec]`
-  _parses a python file and logs the generated ast vs the python ast_
+  - _parses a python file and logs the generated ast vs the python ast_
 - `vr test <shortname> [-f --fail-fast] [-v]`
-  _run a test - shortnames: `pypeg`, `parse`, `dump`_
+  - _run a test - shortnames: `pypeg`, `parse`, `dump`_
 
 ### Debugging/Pofiling
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Scripts
 
 - `vr build`
-  _bundles the typescript files into a javascript bundle)_
+  ⋅⋅⋅ _bundles the typescript files into a javascript bundle)_
 - `vr bundle`
   _an alternative to build - uses deno bundle - no minified version_
 - `vr format`

--- a/src/tokenize/Tokenizer.ts
+++ b/src/tokenize/Tokenizer.ts
@@ -1,3 +1,4 @@
+import type { AST } from "../ast/astnodes.ts";
 import { isSpace } from "../util/str_helpers.ts";
 import { COMMENT, ERRORTOKEN, NL } from "./token.ts";
 import type { TokenInfo } from "./tokenize.ts";
@@ -5,19 +6,22 @@ import type { TokenInfo } from "./tokenize.ts";
 export class Tokenizer {
     _tokengen: Iterator<TokenInfo, TokenInfo>;
     _tokens: TokenInfo[];
+    _cache: { [key: string]: [AST | TokenInfo | null, number] }[];
     _index: number;
     constructor(tokengen: Iterator<TokenInfo, TokenInfo>) {
         this._tokengen = tokengen;
         this._tokens = [];
+        this._cache = [{}];
         this._index = 0;
     }
     _push(): void {
         while (this._index === this._tokens.length) {
             const tok = this._tokengen.next().value;
-            if (tok.type === NL || tok.type === COMMENT) {
+            const type = tok.type;
+            if (type === NL || type === COMMENT) {
                 continue;
             }
-            if (tok.type === ERRORTOKEN && isSpace(tok.string)) {
+            if (type === ERRORTOKEN && isSpace(tok.string)) {
                 continue;
             }
             this._tokens.push(tok);
@@ -25,6 +29,7 @@ export class Tokenizer {
     }
     getnext(): TokenInfo {
         this._push();
+        this._cache.push({});
         return this._tokens[this._index++];
     }
     peek(): TokenInfo {


### PR DESCRIPTION
Did some profiling and the cache was a slow point for the parser
This change improved performance by more than double

A good bench mark was parsing cpython's turtle.py
master - `650ms`
this pr - `270ms`
skulpt - `130ms`


