### PR TITLE
improvements to syntax errors and don't worry about some offsets

### DIFF
--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -10,7 +10,15 @@ switch (test) {
         extra.push("tests/parse.test.ts");
         break;
     case "pypeg":
-        await Deno.run({ cmd: ["python", "-m", "unittest", "tests/test_peg_parser.py", ...Deno.args] }).status();
+        await Deno.run({
+            cmd: [
+                "python",
+                "-m",
+                "unittest",
+                "tests/test_peg_parser.py",
+                ...Deno.args.filter((arg) => arg !== "pypeg"),
+            ],
+        }).status();
         Deno.exit();
         break; // just to keep ts happy
     /** @todo the default should be to do nothing here and run all the tests */

--- a/src/parser/parse_string.ts
+++ b/src/parser/parse_string.ts
@@ -321,6 +321,10 @@ function fstring_find_expr(
 
     const expr_end = i;
 
+    if (expr_start >= expr_end) {
+        unexpected_end_of_string(p);
+    }
+
     /* Compile the expression as soon as possible, so we show errors
        related to the expression before errors related to the
        conversion or format_spec. */

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -163,7 +163,7 @@ export class Parser {
         ...formatArgs: string[]
     ): never {
         if (this.start_rule === StartRule.FSTRING_INPUT) {
-            /** @todo */
+            msg = "f-string: " + msg;
         }
 
         /** @todo should we just set the error indicator and return null then check this in the memoize decorator? */
@@ -171,17 +171,12 @@ export class Parser {
         for (const arg of formatArgs) {
             msg = msg.replace("%s", arg);
         }
-        let i = this.mark() - 1;
-        let errLine = "";
-        while (i >= 0) {
-            const tok = this._tokens[i];
-            if (tok.lineno === lineno) {
-                errLine = tok.line;
-                break;
-            }
-            i--;
+        let tok = this.diagnose();
+        let i = this._tokens.length - 1;
+        while (tok.lineno !== lineno && i > 0) {
+            tok = this._tokens[--i];
         }
-        throw new errType(msg, [this.filename, lineno, offset, errLine]);
+        throw new errType(msg, [this.filename, lineno, offset, tok.line]);
     }
 
     raise_error_invalid_target(type: TARGETS_TYPE, e: expr | null): never {

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -16,4 +16,6 @@ async function doTest(source: string) {
 
 const files: string[] = JSON.parse(Deno.env.get("_TESTFILES") || "[]");
 
-await runTests(doTest, { files, skip: new Set(), failFast: false });
+// t542.py uses unicode characters which have different bytes offsets compared with
+// skulpt parser which uses javascript string offsets
+await runTests(doTest, { files, skip: new Set(["t542.py"]), failFast: false });


### PR DESCRIPTION
close #63 
Let's ignore issues with unicode characters. (skip test `t542.py`)
Our parser uses javascript strings
Python parser uses bytes.
And let's not worry about astral codepoints.


further addresses #75 by adjusting pypeg tests to ignore offsets where it's relevant to do so.

Fixes syntax errors showing the correct line and including pypeg tests for this.


```
Ran 361 tests in 36.436s

OK (skipped=1)
```