### PR TITLE
Idea for the Constant interface

### DIFF
--- a/src/ast/constants.ts
+++ b/src/ast/constants.ts
@@ -3,7 +3,7 @@
 
 import { assert } from "../util/assert.ts";
 
-export enum ConstantType {
+export const enum ConstantType {
     str = "str",
     int = "int",
     float = "float",

--- a/src/ast/constants.ts
+++ b/src/ast/constants.ts
@@ -3,9 +3,21 @@
 
 import { assert } from "../util/assert.ts";
 
+export enum ConstantType {
+    str = "str",
+    int = "int",
+    float = "float",
+    complex = "complex",
+    bytes = "bytes",
+    none = "none",
+    bool = "bool",
+    ellipsis = "ellipsis",
+    long = "long",
+}
+
 // deno-lint-ignore no-explicit-any
-export class pyConstant<V = any> {
-    static _name = "constant";
+export abstract class pyConstant<V = any> {
+    abstract type: ConstantType;
     _v: V;
     constructor(v: V) {
         this._v = v;
@@ -16,27 +28,21 @@ export class pyConstant<V = any> {
     valueOf(): V {
         return this._v;
     }
-    get [Symbol.toStringTag]() {
-        return (this.constructor as typeof pyConstant)._name;
-    }
 }
 
-const escape = { "\n": "n", "\r": "r", "\t": "t", "\\": "\\", "'": "'", '"': '"' };
+const _escape = { "\n": "n", "\r": "r", "\t": "t", "\\": "\\", "'": "'", '"': '"' };
 
 function _stringRepr(v: string): string {
-    let quote = "'";
-    if (v.includes("'") && !v.includes('"')) {
-        quote = '"';
-    }
+    const quote = v.includes("'") && !v.includes('"') ? '"' : "'";
     const toEscape = new RegExp(`([\\n\\r\\\\\t${quote}])`, "g");
-    v = v.replace(toEscape, (_m, m1) => "\\" + escape[m1 as keyof typeof escape]);
+    v = v.replace(toEscape, (_m, m1) => "\\" + _escape[m1 as keyof typeof _escape]);
     // deno-lint-ignore no-control-regex
     v = v.replace(/[\x00-\x1f]/g, (m) => "\\x" + m.charCodeAt(0).toString(16).padStart(2, "0"));
     return quote + v + quote;
 }
 
 export class pyStr extends pyConstant<string> {
-    static _name = "str";
+    type = ConstantType.str;
     toString() {
         return _stringRepr(this._v);
     }
@@ -45,18 +51,18 @@ export class pyStr extends pyConstant<string> {
 // this could also be a JSBI.BigInt
 // relying on Skulpt adding JSBI to the window object if bigint isn't available
 export class pyInt extends pyConstant<number | bigint> {
-    static _name = "int";
+    type = ConstantType.int;
 }
 
 export class pyLong extends pyConstant<number | bigint> {
-    static _name = "long";
+    type = ConstantType.long;
     toString() {
         return this._v.toString() + "L";
     }
 }
 
 export class pyFloat extends pyConstant<number> {
-    static _name = "float";
+    type = ConstantType.float;
     toString() {
         const v = this._v;
         if ((v > 0 && v < 0.0001) || (v < 0 && v > -0.0001)) {
@@ -69,41 +75,40 @@ export class pyFloat extends pyConstant<number> {
 }
 
 export class pyComplex extends pyConstant<{ real: number; imag: number }> {
-    static _name = "complex";
+    type = ConstantType.complex;
     constructor({ real = 0, imag }: { real?: number; imag: number }) {
         // this is from the tokenizer and we shouldn't have a real except 0.
         assert(real === 0);
         super({ real, imag });
     }
     toString() {
-        const { imag } = this._v;
-        return imag + "j";
+        return this._v.imag + "j";
     }
 }
 
 export class pyBytes extends pyConstant<Uint8Array> {
-    static _name = "bytes";
+    type = ConstantType.bytes;
     toString() {
         return "b" + _stringRepr(new TextDecoder().decode(this._v));
     }
 }
 
 export class pyNoneType extends pyConstant<null> {
-    static _name = "NoneType";
+    type = ConstantType.none;
     toString() {
         return "None";
     }
 }
 
 export class pyBool extends pyConstant<boolean> {
-    static _name = "bool";
+    type = ConstantType.bool;
     toString() {
         return this._v ? "True" : "False";
     }
 }
 
 export class pyEllipsisType extends pyConstant<"..."> {
-    static _name = "ellipsis";
+    type = ConstantType.ellipsis;
     toString() {
         return "Ellipsis";
     }


### PR DESCRIPTION
```javascript
switch case (e.value.type) {
    case ConstantType.str:
```

Remove the `_name` on these skulpt like classes since we don't use it for `ast dump` purposes.

I figured making the enum a `str` meant if you wanted you could also get the type name 🤷 
I went with the public field declaration for `type`.

I had a look at the compilation and this ends up as 

```javascript
export class pyConstant {
    constructor(v) {
        this._v = v;
    }
    toString() {
        return String(this._v);
    }
    valueOf() {
        return this._v;
    }
}
export class pyInt extends pyConstant {
    constructor() {
        super(...arguments);
        this.type = ConstantType.int;
    }
}
```


