### PR TITLE
some symtable tweaks

### DIFF
--- a/scripts/symtable.ts
+++ b/scripts/symtable.ts
@@ -2,7 +2,7 @@
 import { Colors, parse } from "../deps.ts";
 import { runParserFromFile } from "../src/parser/parse.ts";
 import type { expr, mod } from "../src/ast/astnodes.ts";
-import { buildSymbolTable, SymbolTable } from "../src/parser/symtable.ts";
+import { buildSymbolTable, SymbolTable } from "../src/symtable/mod.ts";
 
 const argv = parse(Deno.args, {
     default: { mode: "exec" } /** @todo this doesn't get passed to the python script */,

--- a/src/parser/symtable.ts
+++ b/src/parser/symtable.ts
@@ -860,7 +860,6 @@ export class SymbolTable {
     handleNamedExpr(e: NamedExpr) {
         assert(this.cur !== null, "need current scope for namedExpr");
         if (this.cur.comp_iter_expr > 0) {
-            /** @todo -- needs line number etc */
             throw new pySyntaxError("Assignment isn't allowed in a comprehension iterable expression", [
                 this.filename,
                 e.lineno,

--- a/src/parser/symtable.ts
+++ b/src/parser/symtable.ts
@@ -1443,7 +1443,9 @@ export class SymbolTable {
                 this.visitExpr(for_.target);
                 this.visitExpr(for_.iter);
                 this.SEQ(this.visitStmt, for_.body);
-                if (for_.orelse.length !== 0) this.SEQ(this.visitStmt, for_.orelse);
+                if (for_.orelse.length !== 0) {
+                    this.SEQ(this.visitStmt, for_.orelse);
+                }
                 break;
             }
             case ASTKind.While: {
@@ -1451,7 +1453,9 @@ export class SymbolTable {
 
                 this.visitExpr(while_.test);
                 this.SEQ(this.visitStmt, while_.body);
-                if (while_.orelse.length !== 0) this.SEQ(this.visitStmt, while_.orelse);
+                if (while_.orelse.length !== 0) {
+                    this.SEQ(this.visitStmt, while_.orelse);
+                }
                 break;
             }
             case ASTKind.If: {
@@ -1460,7 +1464,9 @@ export class SymbolTable {
                 /* XXX if 0: and lookup_yield() hacks */
                 this.visitExpr(if_.test);
                 this.SEQ(this.visitStmt, if_.body);
-                if (if_.orelse.length !== 0) this.SEQ(this.visitStmt, if_.orelse);
+                if (if_.orelse.length !== 0) {
+                    this.SEQ(this.visitStmt, if_.orelse);
+                }
                 break;
             }
             case ASTKind.Raise: {

--- a/src/symtable/Symbol.ts
+++ b/src/symtable/Symbol.ts
@@ -1,0 +1,113 @@
+import { SymbolTableScope } from "./SymbolTableScope.ts";
+import { SYMTAB_CONSTS } from "./util.ts";
+
+export class Symbol_ {
+    __name: string;
+    __flags: number;
+    __scope: number;
+    __namespaces: SymbolTableScope[] | null = null;
+    __module_scope = false;
+
+    constructor(name: string, flags: number, namespaces: SymbolTableScope[] | null = null, moduleScope = false) {
+        this.__name = name;
+        this.__flags = flags;
+        this.__scope = (flags >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK; // like PyST_GetScope()
+        this.__namespaces = namespaces;
+        this.__module_scope = moduleScope;
+    }
+
+    get [Symbol.toStringTag]() {
+        return '<symbol "' + this.__name + '">';
+    }
+
+    get_name() {
+        return this.__name;
+    }
+
+    is_referenced() {
+        return !!(this.__flags & SYMTAB_CONSTS.USE);
+    }
+
+    is_parameter() {
+        return !!(this.__flags & SYMTAB_CONSTS.DEF_PARAM);
+    }
+
+    is_global() {
+        /* Return *True* if the symbol is global. */
+        return !!(
+            [SYMTAB_CONSTS.GLOBAL_IMPLICIT, SYMTAB_CONSTS.GLOBAL_EXPLICIT].includes(this.__scope) ||
+            (this.__module_scope && !!(this.__flags & SYMTAB_CONSTS.DEF_BOUND))
+        );
+    }
+
+    is_nonlocal() {
+        return !!(this.__flags & SYMTAB_CONSTS.DEF_NONLOCAL);
+    }
+
+    is_declared_global() {
+        return !!(this.__scope === SYMTAB_CONSTS.GLOBAL_EXPLICIT);
+    }
+
+    is_local() {
+        /* Return *True* if the symbol is local. */
+        return !!(
+            [SYMTAB_CONSTS.LOCAL, SYMTAB_CONSTS.CELL].includes(this.__scope) ||
+            (this.__module_scope && this.__flags & SYMTAB_CONSTS.DEF_BOUND)
+        );
+    }
+
+    is_annotated() {
+        return !!(this.__flags & SYMTAB_CONSTS.DEF_ANNOT);
+    }
+
+    is_free() {
+        return !!(this.__scope === SYMTAB_CONSTS.FREE);
+    }
+
+    is_imported() {
+        return !!(this.__flags & SYMTAB_CONSTS.DEF_IMPORT);
+    }
+
+    is_assigned() {
+        return !!(this.__flags & SYMTAB_CONSTS.DEF_LOCAL);
+    }
+
+    is_comprehension() {
+        return !!(this.__flags & SYMTAB_CONSTS.DEF_COMP_ITER);
+    }
+
+    is_namespace() {
+        /*
+        Returns true if name binding introduces new namespace.
+
+        If the name is used as the target of a function or class
+        statement, this will be true.
+
+        Note that a single name can be bound to multiple objects.  If
+        is_namespace() is true, the name may also be bound to other
+        objects, like an int or list, that does not introduce a new
+        namespace.
+        */
+        return this.__namespaces !== null && this.__namespaces.length > 0;
+    }
+
+    get_namespaces() {
+        /* Return a list of namespaces bound to this name */
+        return this.__namespaces;
+    }
+
+    get_namespace() {
+        /*
+        Returns the single namespace bound to this name.
+
+        Raises ValueError if the name is bound to multiple namespaces.
+        */
+
+        if (this.__namespaces?.length !== 1) {
+            throw Error("name is bound to multiple namespaces");
+            // todo: This should be a value error maybe
+        }
+
+        return this.__namespaces[0];
+    }
+}

--- a/src/symtable/SymbolTable.ts
+++ b/src/symtable/SymbolTable.ts
@@ -1,701 +1,9 @@
-import type {
-    AST,
-    BinOp,
-    BoolOp,
-    ClassDef,
-    expr,
-    FunctionDef,
-    Lambda,
-    Name,
-    NamedExpr,
-    stmt,
-    UnaryOp,
-    IfExp,
-    Set_,
-    Dict,
-    arguments_,
-    Yield,
-    YieldFrom,
-    Await,
-    Compare,
-    Call,
-    JoinedStr,
-    FormattedValue,
-    Attribute,
-    Subscript,
-    Starred,
-    Slice,
-    List,
-    Tuple,
-    arg,
-    keyword,
-    GeneratorExp,
-    comprehension,
-    ListComp,
-    SetComp,
-    DictComp,
-    Return,
-    Delete,
-    Assign,
-    AnnAssign,
-    AsyncFor,
-    AsyncWith,
-    AsyncFunctionDef,
-    With,
-    Expr,
-    Nonlocal,
-    Global,
-    Assert,
-    Try,
-    Raise,
-    If,
-    While,
-    For,
-    AugAssign,
-    Import,
-    alias,
-    ImportFrom,
-    withitem,
-    ExceptHandler,
-    mod,
-    Module,
-    Expression,
-    Interactive,
-} from "../ast/astnodes.ts";
+import type * as astnode from "../ast/astnodes.ts";
 import { ASTKind, Load } from "../ast/astnodes.ts";
 import { pySyntaxError } from "../ast/errors.ts";
-import { assert } from "./pegen.ts";
-
-export enum BlockType {
-    ModuleBlock = "module",
-    FunctionBlock = "function",
-    ClassBlock = "class",
-    AnnotationBlock = "annotation",
-}
-
-function inplaceMerge<T>(left: Set<T>, right: Set<T>) {
-    for (const v of right) {
-        left.add(v);
-    }
-}
-
-const LEADING_UNDERSCORE_REGEX = /^_+/;
-
-export enum SYMTAB_CONSTS {
-    DEF_GLOBAL = 1 /* global stmt */,
-    DEF_LOCAL = 2 /* assignment in code block */,
-    DEF_PARAM = 2 << 1 /* formal parameter */,
-    DEF_NONLOCAL = 2 << 2 /* nonlocal stmt */,
-    USE = 2 << 3 /* name is used */,
-    DEF_FREE = 2 << 4 /* name used but not defined in nested block */,
-    DEF_FREE_CLASS = 2 << 5 /* free variable from class's method */,
-    DEF_IMPORT = 2 << 6 /* assignment occurred via import */,
-    DEF_ANNOT = 2 << 7 /* this name is annotated */,
-    DEF_COMP_ITER = 2 << 8 /* this name is a comprehension iteration variable */,
-    DEF_BOUND = DEF_LOCAL | DEF_PARAM | DEF_IMPORT,
-
-    /* GLOBAL_EXPLICIT and GLOBAL_IMPLICIT are used internally by the symbol
-       table.  GLOBAL is returned from PyST_GetScope() for either of them.
-       It is stored in ste_symbols at bits 12-15.
-    */
-
-    SCOPE_OFFSET = 11,
-    SCOPE_MASK = DEF_GLOBAL | DEF_LOCAL | DEF_PARAM | DEF_NONLOCAL,
-    LOCAL = 1,
-    GLOBAL_EXPLICIT = 2,
-    GLOBAL_IMPLICIT = 3,
-    FREE = 4,
-    CELL = 5,
-    GENERATOR = 1,
-    GENERATOR_EXPRESSION = 2,
-}
-
-export class Symbol_ {
-    __name: string;
-    __flags: number;
-    __scope: number;
-    __namespaces: SymbolTableScope[] | null = null;
-    __module_scope = false;
-
-    constructor(name: string, flags: number, namespaces: SymbolTableScope[] | null = null, moduleScope = false) {
-        this.__name = name;
-        this.__flags = flags;
-        this.__scope = (flags >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK; // like PyST_GetScope()
-        this.__namespaces = namespaces;
-        this.__module_scope = moduleScope;
-    }
-
-    get [Symbol.toStringTag]() {
-        return '<symbol "' + this.__name + '">';
-    }
-
-    get_name() {
-        return this.__name;
-    }
-
-    is_referenced() {
-        return !!(this.__flags & SYMTAB_CONSTS.USE);
-    }
-
-    is_parameter() {
-        return !!(this.__flags & SYMTAB_CONSTS.DEF_PARAM);
-    }
-
-    is_global() {
-        /* Return *True* if the symbol is global. */
-        return !!(
-            [SYMTAB_CONSTS.GLOBAL_IMPLICIT, SYMTAB_CONSTS.GLOBAL_EXPLICIT].includes(this.__scope) ||
-            (this.__module_scope && !!(this.__flags & SYMTAB_CONSTS.DEF_BOUND))
-        );
-    }
-
-    is_nonlocal() {
-        return !!(this.__flags & SYMTAB_CONSTS.DEF_NONLOCAL);
-    }
-
-    is_declared_global() {
-        return !!(this.__scope === SYMTAB_CONSTS.GLOBAL_EXPLICIT);
-    }
-
-    is_local() {
-        /* Return *True* if the symbol is local. */
-        return !!(
-            [SYMTAB_CONSTS.LOCAL, SYMTAB_CONSTS.CELL].includes(this.__scope) ||
-            (this.__module_scope && this.__flags & SYMTAB_CONSTS.DEF_BOUND)
-        );
-    }
-
-    is_annotated() {
-        return !!(this.__flags & SYMTAB_CONSTS.DEF_ANNOT);
-    }
-
-    is_free() {
-        return !!(this.__scope === SYMTAB_CONSTS.FREE);
-    }
-
-    is_imported() {
-        return !!(this.__flags & SYMTAB_CONSTS.DEF_IMPORT);
-    }
-
-    is_assigned() {
-        return !!(this.__flags & SYMTAB_CONSTS.DEF_LOCAL);
-    }
-
-    is_comprehension() {
-        return !!(this.__flags & SYMTAB_CONSTS.DEF_COMP_ITER);
-    }
-
-    is_namespace() {
-        /*
-        Returns true if name binding introduces new namespace.
-
-        If the name is used as the target of a function or class
-        statement, this will be true.
-
-        Note that a single name can be bound to multiple objects.  If
-        is_namespace() is true, the name may also be bound to other
-        objects, like an int or list, that does not introduce a new
-        namespace.
-        */
-        return this.__namespaces !== null && this.__namespaces.length > 0;
-    }
-
-    get_namespaces() {
-        /* Return a list of namespaces bound to this name */
-        return this.__namespaces;
-    }
-
-    get_namespace() {
-        /*
-        Returns the single namespace bound to this name.
-
-        Raises ValueError if the name is bound to multiple namespaces.
-        */
-
-        if (this.__namespaces?.length !== 1) {
-            throw Error("name is bound to multiple namespaces");
-            // todo: This should be a value error maybe
-        }
-
-        return this.__namespaces[0];
-    }
-}
-
-let astScopeCounter = 0;
-
-export class SymbolTableScope {
-    name: string;
-    varnames: string[];
-    children: SymbolTableScope[] | null;
-    blockType: BlockType;
-    isNested = false;
-    hasFree: boolean;
-    childHasFree: boolean;
-    generator: boolean;
-    varargs: boolean;
-    varkeywords: boolean;
-    returnsValue: boolean;
-    filename: string;
-    lineno: number;
-    colOffset: number;
-    endLineno: number | null | undefined;
-    endColOffset: number | null | undefined;
-    table: SymbolTable;
-    symbols: { [name: string]: number };
-    _funcLocals: string[] | null = null;
-    _funcParams: string[] | null = null;
-    _funcGlobals: string[] | null = null;
-    _funcNonlocals: string[] | null = null;
-    _funcFrees: string[] | null = null;
-    _classMethods: string[] | null = null;
-    comp_iter_expr = 0;
-    comp_iter_target = false;
-    comprehension = false;
-    directives: [string, number, number][] | null = null;
-    coroutine = false;
-    needs_class_closure = false;
-
-    constructor(
-        table: SymbolTable,
-        name: string,
-        type: BlockType,
-        ast: AST,
-        filename: string,
-        lineno: number,
-        colOffset: number,
-        endLineno?: number | null,
-        endColOffset?: number | null
-    ) {
-        this.name = name;
-        this.varnames = [];
-        this.children = null;
-        this.blockType = type;
-
-        this.isNested = false;
-        this.hasFree = false;
-        this.childHasFree = false; // true if child block has free vars including free refs to globals
-        this.generator = false;
-        this.varargs = false;
-        this.varkeywords = false;
-        this.returnsValue = false;
-
-        this.filename = filename;
-        this.lineno = lineno;
-        this.colOffset = colOffset;
-        this.endLineno = endLineno;
-        this.endColOffset = endColOffset;
-
-        this.table = table;
-
-        if (table.cur && (table.cur.isNested || table.cur.blockType === BlockType.FunctionBlock)) {
-            this.isNested = true;
-        }
-
-        ast.scopeId = astScopeCounter++;
-        table.stss[ast.scopeId] = this;
-
-        // cache of Symbols for returning to other parts of code
-        this.symbols = {};
-    }
-
-    get_type() {
-        return this.blockType;
-    }
-
-    get_name() {
-        return this.name;
-    }
-
-    get_lineno() {
-        return this.lineno;
-    }
-
-    is_nested() {
-        return this.isNested;
-    }
-
-    has_children() {
-        return !!(this.children && this.children.length > 0);
-    }
-
-    get_children() {
-        return this.children || [];
-    }
-
-    get_identifiers() {
-        return this._identsMatching(function () {
-            return true;
-        });
-    }
-
-    getSymbol(name: string): number {
-        return this.symbols[name];
-    }
-
-    lookup(name: string): Symbol_ {
-        return new Symbol_(name, this.symbols[name], this.__check_children(name), this.name === "top");
-        // let sym;
-        // if (!(name in this.symbols)) {
-        //     const flags = this.symFlags[name];
-        //     const namespaces = this.__check_children(name);
-        //     sym = this.symbols[name] = new Symbol_(name, flags, namespaces);
-        // } else {
-        //     sym = this.symbols[name];
-        // }
-        // return sym;
-    }
-
-    __check_children(name: string): SymbolTableScope[] | null {
-        if (this.children) {
-            return this.children.filter((c) => c.name === name);
-        }
-
-        return null;
-    }
-
-    _identsMatching(f: (flag: number) => boolean): string[] {
-        return Object.entries(this.symbols)
-            .filter(([_, v]) => f(v))
-            .map(([k, _]) => k);
-    }
-
-    get_parameters(): string[] {
-        assert(this.get_type() === "function", "get_parameters only valid for function scopes");
-        if (this._funcParams === null) {
-            this._funcParams = this._identsMatching((x) => !!(x & SYMTAB_CONSTS.DEF_PARAM));
-        }
-        return this._funcParams;
-    }
-
-    get_locals(): string[] {
-        if (this._funcLocals === null) {
-            const locs = [SYMTAB_CONSTS.LOCAL, SYMTAB_CONSTS.CELL];
-            const test = (x: number) => locs.includes((x >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK);
-            this._funcLocals = this._identsMatching(test);
-        }
-        return this._funcLocals;
-    }
-
-    get_globals(): string[] {
-        assert(this.get_type() === "function", "get_globals only valid for function scopes");
-        if (this._funcGlobals === null) {
-            this._funcGlobals = this._identsMatching(function (x) {
-                const masked = (x >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK;
-                return masked === SYMTAB_CONSTS.GLOBAL_IMPLICIT || masked === SYMTAB_CONSTS.GLOBAL_EXPLICIT;
-            });
-        }
-        return this._funcGlobals;
-    }
-
-    get_nonlocals(): string[] {
-        if (this._funcNonlocals === null) {
-            this._funcNonlocals = this._identsMatching((x) => !!(x & SYMTAB_CONSTS.DEF_NONLOCAL));
-        }
-        return this._funcNonlocals;
-    }
-
-    get_frees(): string[] {
-        assert(this.get_type() === "function", "get_frees only valid for function scopes");
-        if (this._funcFrees === null) {
-            this._funcFrees = this._identsMatching(function (x) {
-                const masked = (x >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK;
-                return masked === SYMTAB_CONSTS.FREE;
-            });
-        }
-        return this._funcFrees;
-    }
-
-    get_methods() {
-        assert(this.get_type() === "class", "get_methods only valid for class scopes");
-        if (this._classMethods === null) {
-            this._classMethods = this.children?.map((c) => c.name) ?? [];
-        }
-        return this._classMethods;
-    }
-
-    get_scope(name: string): number {
-        const v = this.symbols[name];
-        if (v === undefined) {
-            return 0;
-        }
-        return (v >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK;
-    }
-
-    dropClassFree(free: Set<string>) {
-        free.delete("__class__");
-
-        this.needs_class_closure = true;
-    }
-
-    errorAtDirective(name: string, errorMessage: string): never {
-        assert(this.directives);
-        for (const [directiveName, lineno, colOffset] of this.directives) {
-            if (directiveName === name) {
-                throw new pySyntaxError(errorMessage, [this.filename, lineno, colOffset, ""]);
-            }
-        }
-
-        throw new Error("BUG: internal directive bookkeeping broken");
-    }
-
-    /* Decide on scope of name, given flags.
-    The namespace dictionaries may be modified to record information
-    about the new name.  For example, a new global will add an entry to
-    global.  A name that was global can be changed to local.
-    */
-    analyzeName(
-        scopes: { [name: string]: number },
-        name: string,
-        flags: number,
-        bound: Set<string> | null,
-        local: Set<string>,
-        free: Set<string>,
-        global: Set<string>
-    ) {
-        if (flags & SYMTAB_CONSTS.DEF_GLOBAL) {
-            if (flags & SYMTAB_CONSTS.DEF_NONLOCAL) {
-                this.errorAtDirective(name, `name '${name}' is nonlocal and global`);
-            }
-            scopes[name] = SYMTAB_CONSTS.GLOBAL_EXPLICIT;
-            global.add(name);
-            if (bound) {
-                bound.delete(name);
-            }
-            return;
-        }
-
-        if (flags & SYMTAB_CONSTS.DEF_NONLOCAL) {
-            if (bound === null) {
-                this.errorAtDirective(name, "nonlocal declaration not allowed at module level");
-            }
-            if (bound.has(name)) {
-                this.errorAtDirective(name, `no binding for nonlocal '${name}' found`);
-            }
-            scopes[name] = SYMTAB_CONSTS.FREE;
-            this.hasFree = true;
-            free.add(name);
-            return;
-        }
-
-        if (flags & SYMTAB_CONSTS.DEF_BOUND) {
-            scopes[name] = SYMTAB_CONSTS.LOCAL;
-            local.add(name);
-            global.delete(name);
-            return;
-        }
-
-        /* If an enclosing block has a binding for this name, it
-        is a free variable rather than a global variable.
-        Note that having a non-NULL bound implies that the block
-        is nested.
-        */
-        if (bound && bound.has(name)) {
-            scopes[name] = SYMTAB_CONSTS.FREE;
-            this.hasFree = true;
-            free.add(name);
-            return;
-        }
-
-        /* If a parent has a global statement, then call it global
-        explicit?  It could also be global implicit.
-        */
-
-        if (global.has(name)) {
-            scopes[name] = SYMTAB_CONSTS.GLOBAL_IMPLICIT;
-            return;
-        }
-
-        if (this.isNested) {
-            this.hasFree = true;
-        }
-
-        scopes[name] = SYMTAB_CONSTS.GLOBAL_IMPLICIT;
-    }
-
-    analyzeChildBlock(bound: Set<string>, free: Set<string>, global: Set<string>, childFree: Set<string>) {
-        /* Copy the bound and global dictionaries.
-        These dictionaries are used by all blocks enclosed by the
-        current block.  The analyze_block() call modifies these
-        dictionaries.
-        */
-        const tempBound = new Set(bound);
-        const tempFree = new Set(free);
-        const tempGlobal = new Set(global);
-
-        this.analyzeBlock(tempBound, tempFree, tempGlobal);
-
-        inplaceMerge(childFree, tempFree);
-    }
-
-    analyzeCells(scopes: { [name: string]: number }, free: Set<string>) {
-        for (const [name, scope] of Object.entries(scopes)) {
-            if (scope !== SYMTAB_CONSTS.LOCAL) {
-                continue;
-            }
-
-            if (!free.has(name)) {
-                continue;
-            }
-            /* Replace LOCAL with CELL for this name, and remove
-            from free. It is safe to replace the value of name
-            in the dict, because it will not cause a resize.
-            */
-            scopes[name] = SYMTAB_CONSTS.CELL;
-            free.delete(name);
-        }
-    }
-
-    updateSymbols(
-        scopes: { [name: string]: number },
-        bound: Set<string> | null,
-        free: Set<string>,
-        classFlag: boolean
-    ) {
-        /* Update scope information for all symbols in this scope */
-        for (let [name, flags] of Object.entries(this.symbols)) {
-            flags |= scopes[name] << SYMTAB_CONSTS.SCOPE_OFFSET;
-            this.symbols[name] = flags;
-        }
-
-        /* Record not yet resolved free variables from children (if any) */
-        const vFree = SYMTAB_CONSTS.FREE << SYMTAB_CONSTS.SCOPE_OFFSET;
-
-        for (const name in free) {
-            const v = this.symbols[name];
-
-            /* Handle symbol that already exists in this scope */
-            if (v) {
-                /* Handle a free variable in a method of
-                   the class that has the same name as a local
-                   or global in the class scope.
-                */
-                if (classFlag && v & (SYMTAB_CONSTS.DEF_BOUND | SYMTAB_CONSTS.DEF_GLOBAL)) {
-                    const flags = v | SYMTAB_CONSTS.DEF_FREE_CLASS;
-                    this.symbols[name] = flags;
-                }
-                /* It's a cell, or already free in this scope */
-                continue;
-            }
-            /* Handle global symbol */
-            if (bound && !bound.has(name)) {
-                continue; /* it's a global */
-            }
-            /* Propagate new free symbol up the lexical stack */
-            this.symbols[name] = vFree;
-        }
-    }
-
-    analyzeBlock(bound: Set<string> | null, free: Set<string>, global: Set<string>) {
-        const local = new Set<string>(); /* collect new names bound in block */
-
-        const scopes = {}; /* collect scopes defined for each name */
-
-        /* Allocate new global and bound variable dictionaries.  These
-        dictionaries hold the names visible in nested blocks.  For
-        BlockType.ClassBlocks, the bound and global names are initialized
-        before analyzing names, because class bindings aren't
-        visible in methods.  For other blocks, they are initialized
-        after names are analyzed.
-        */
-
-        /* TODO(jhylton): Package these dicts in a struct so that we
-        can write reasonable helper functions?
-        */
-        const newglobal = new Set<string>();
-        const newfree = new Set<string>();
-        const newbound = new Set<string>();
-
-        /* Class namespace has no effect on names visible in
-        nested functions, so populate the global and bound
-        sets to be passed to child blocks before analyzing
-        this one.
-        */
-        if (this.blockType === BlockType.ClassBlock) {
-            /* Pass down known globals */
-            inplaceMerge(newglobal, global);
-
-            /* Pass down previously bound symbols */
-            if (bound) {
-                inplaceMerge(newbound, bound);
-            }
-        }
-
-        for (const [name, flags] of Object.entries(this.symbols)) {
-            this.analyzeName(scopes, name, flags, bound, local, free, global);
-        }
-
-        /* Populate global and bound sets to be passed to children. */
-        if (this.blockType !== BlockType.ClassBlock) {
-            /* Add function locals to bound set */
-            if (this.blockType === BlockType.FunctionBlock) {
-                inplaceMerge(newbound, local);
-            }
-            /* Pass down previously bound symbols */
-            if (bound) {
-                inplaceMerge(newbound, bound);
-            }
-            /* Pass down known globals */
-            inplaceMerge(newglobal, global);
-        } else {
-            /* Special-case __class__ */
-            newbound.add("__class__");
-        }
-
-        /* Recursively call analyze_child_block() on each child block.
-        newbound, newglobal now contain the names visible in
-        nested blocks.  The free variables in the children will
-        be collected in allfree.
-        */
-        const allfree = new Set<string>();
-        for (const entry of this.children || []) {
-            entry.analyzeChildBlock(newbound, newfree, newglobal, allfree);
-            if (entry.hasFree || entry.childHasFree) {
-                this.childHasFree = true;
-            }
-        }
-
-        inplaceMerge(newfree, allfree);
-
-        /* Check if any local variables must be converted to cell variables */
-        if (this.blockType === BlockType.FunctionBlock) {
-            this.analyzeCells(scopes, newfree);
-        } else if (this.blockType === BlockType.ClassBlock) {
-            this.dropClassFree(newfree);
-        }
-
-        /* Records the results of the analysis in the symbol table entry */
-        this.updateSymbols(scopes, bound, newfree, this.blockType === BlockType.ClassBlock);
-
-        inplaceMerge(free, newfree);
-    }
-}
-
-function mangle(privateobj: string | null, ident: string) {
-    /* Name mangling: __private becomes _classname__private.
-       This is independent from how the name is used. */
-    if (privateobj === null /* !PyUnicode_Check(privateobj) || */ || !ident.startsWith("__")) {
-        return ident;
-    }
-    /* Don't mangle __id__ or names with dots.
-          The only time a name with a dot can occur is when
-          we are compiling an import statement that has a
-          package name.
-          TODO(jhylton): Decide whether we want to support
-          mangling of the module name, e.g. __M.X.
-       */
-    if (ident.endsWith("__") || ident.includes(".")) {
-        return ident; /* Don't mangle __whatever__ */
-    }
-
-    /* Strip leading underscores from class name */
-    const stripped = privateobj.replace(LEADING_UNDERSCORE_REGEX, "");
-    if (stripped.length === 0) {
-        return ident; /* Don't mangle if class is just underscores */
-    }
-
-    /* ident = "_" + priv[ipriv:] + ident # i.e. 1+plen+nlen bytes */
-    return `_${stripped}${ident}`;
-}
+import { assert } from "../parser/pegen.ts";
+import { SymbolTableScope } from "./SymbolTableScope.ts";
+import { SYMTAB_CONSTS, mangle, BlockType } from "./util.ts";
 
 export class SymbolTable {
     filename: string;
@@ -717,7 +25,7 @@ export class SymbolTable {
         return this.curClass;
     }
 
-    getStsForAst(ast: AST) {
+    getStsForAst(ast: astnode.AST) {
         assert(ast.scopeId !== undefined, "ast wasn't added to st?");
         const v = this.stss[ast.scopeId];
         assert(v !== undefined, "unknown sym tab entry");
@@ -803,7 +111,7 @@ export class SymbolTable {
         this.cur.directives.push([mangled, lineno, colOffset]);
     }
 
-    extendNamedexprScope(e: Name) {
+    extendNamedexprScope(e: astnode.Name) {
         assert(this.stack);
         assert(e._kind === ASTKind.Name);
 
@@ -825,7 +133,7 @@ export class SymbolTable {
                 continue;
             }
 
-            /* If we find a BlockType.FunctionBlock entry, add as GLOBAL/LOCAL or NONLOCAL/LOCAL */
+            /* If we find a BlockType.FunctionBlock entry, add as astnode.GLOBAL/LOCAL or NONLOCAL/LOCAL */
             if (ste.blockType === BlockType.FunctionBlock) {
                 const targetInScope = ste.getSymbol(targetName);
                 if (targetInScope & SYMTAB_CONSTS.DEF_GLOBAL) {
@@ -836,7 +144,7 @@ export class SymbolTable {
                 this.recordDirective(targetName, e.lineno, e.col_offset);
                 return this.addDef(targetName, SYMTAB_CONSTS.DEF_LOCAL, ste);
             }
-            /* If we find a BlockType.ModuleBlock entry, add as GLOBAL */
+            /* If we find a BlockType.ModuleBlock entry, add as astnode.GLOBAL */
             if (ste.blockType === BlockType.ModuleBlock) {
                 this.addDef(targetName, SYMTAB_CONSTS.DEF_GLOBAL);
                 this.recordDirective(targetName, e.lineno, e.col_offset);
@@ -857,7 +165,7 @@ export class SymbolTable {
         );
     }
 
-    handleNamedExpr(e: NamedExpr) {
+    handleNamedExpr(e: astnode.NamedExpr) {
         assert(this.cur !== null, "need current scope for namedExpr");
         if (this.cur.comp_iter_expr > 0) {
             throw new pySyntaxError("Assignment isn't allowed in a comprehension iterable expression", [
@@ -869,7 +177,7 @@ export class SymbolTable {
         }
         if (this.cur.comprehension) {
             /* Inside a comprehension body, so find the right target scope */
-            this.extendNamedexprScope(e.target as Name);
+            this.extendNamedexprScope(e.target as astnode.Name);
         }
         this.visitExpr(e.value);
         this.visitExpr(e.target);
@@ -878,7 +186,7 @@ export class SymbolTable {
     enterBlock(
         name: string,
         block: BlockType,
-        ast: AST,
+        ast: astnode.AST,
         lineno: number,
         colOffset: number,
         endLineno?: number | null,
@@ -898,7 +206,7 @@ export class SymbolTable {
         this.stack.push(ste);
         const prev = this.cur;
 
-        /* bpo-37757: For now, disallow *all* assignment expressions in the
+        /* bpo-37757: astnode.For now, disallow *all* assignment expressions in the
          * outermost iterator expression of a comprehension, even those inside
          * a nested comprehension or a lambda expression.
          */
@@ -941,11 +249,11 @@ export class SymbolTable {
     }
 
     handleComprehension(
-        e: GeneratorExp | ListComp | SetComp | DictComp,
+        e: astnode.GeneratorExp | astnode.ListComp | astnode.SetComp | astnode.DictComp,
         scopeName: string,
-        generators: comprehension[],
-        elt: expr,
-        value: expr | null
+        generators: astnode.comprehension[],
+        elt: astnode.expr,
+        value: astnode.expr | null
     ) {
         assert(this.cur);
         const isGenerator = e._kind === ASTKind.GeneratorExp;
@@ -1001,27 +309,27 @@ export class SymbolTable {
         }
     }
 
-    visitKeyword(k: keyword) {
+    visitKeyword(k: astnode.keyword) {
         this.visitExpr(k.value);
     }
 
-    visitGenexp(e: GeneratorExp) {
+    visitGenexp(e: astnode.GeneratorExp) {
         return this.handleComprehension(e, "genexpr", e.generators, e.elt, null);
     }
 
-    visitListcomp(e: ListComp) {
+    visitListcomp(e: astnode.ListComp) {
         return this.handleComprehension(e, "listcomp", e.generators, e.elt, null);
     }
 
-    visitSetcomp(e: SetComp) {
+    visitSetcomp(e: astnode.SetComp) {
         return this.handleComprehension(e, "setcomp", e.generators, e.elt, null);
     }
 
-    visitDictcomp(e: DictComp) {
+    visitDictcomp(e: astnode.DictComp) {
         return this.handleComprehension(e, "dictcomp", e.generators, e.key, e.value);
     }
 
-    visitComprehension(lc: comprehension) {
+    visitComprehension(lc: astnode.comprehension) {
         assert(this.cur);
         this.cur.comp_iter_target = true;
         this.visitExpr(lc.target);
@@ -1035,25 +343,25 @@ export class SymbolTable {
         }
     }
 
-    visitExpr(e: expr) {
+    visitExpr(e: astnode.expr) {
         switch (e._kind) {
             case ASTKind.NamedExpr:
-                this.handleNamedExpr(e as NamedExpr);
+                this.handleNamedExpr(e as astnode.NamedExpr);
                 break;
             case ASTKind.BoolOp:
-                this.SEQ(this.visitExpr, (e as BoolOp).values);
+                this.SEQ(this.visitExpr, (e as astnode.BoolOp).values);
                 break;
             case ASTKind.BinOp: {
-                const binOp = e as BinOp;
+                const binOp = e as astnode.BinOp;
                 this.visitExpr(binOp.left);
                 this.visitExpr(binOp.right);
                 break;
             }
             case ASTKind.UnaryOp:
-                this.visitExpr((e as UnaryOp).operand);
+                this.visitExpr((e as astnode.UnaryOp).operand);
                 break;
             case ASTKind.Lambda: {
-                const lambda = e as Lambda;
+                const lambda = e as astnode.Lambda;
                 if (lambda.args.defaults.length !== 0) {
                     this.SEQ(this.visitExpr, lambda.args.defaults);
                 }
@@ -1075,36 +383,36 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.IfExp: {
-                const ifExp = e as IfExp;
+                const ifExp = e as astnode.IfExp;
                 this.visitExpr(ifExp.test);
                 this.visitExpr(ifExp.body);
                 this.visitExpr(ifExp.orelse);
                 break;
             }
             case ASTKind.Dict: {
-                const dict = e as Dict;
+                const dict = e as astnode.Dict;
                 this.SEQ(this.visitExpr, dict.keys);
                 this.SEQ(this.visitExpr, dict.values);
                 break;
             }
             case ASTKind.Set_:
-                this.SEQ(this.visitExpr, (e as Set_).elts);
+                this.SEQ(this.visitExpr, (e as astnode.Set_).elts);
                 break;
             case ASTKind.GeneratorExp:
-                this.visitGenexp(e as GeneratorExp);
+                this.visitGenexp(e as astnode.GeneratorExp);
                 break;
             case ASTKind.ListComp:
-                this.visitListcomp(e as ListComp);
+                this.visitListcomp(e as astnode.ListComp);
                 break;
             case ASTKind.SetComp:
-                this.visitSetcomp(e as SetComp);
+                this.visitSetcomp(e as astnode.SetComp);
                 break;
             case ASTKind.DictComp:
-                this.visitDictcomp(e as DictComp);
+                this.visitDictcomp(e as astnode.DictComp);
                 break;
             case ASTKind.Yield: {
                 assert(this.cur !== null);
-                const yield_ = e as Yield;
+                const yield_ = e as astnode.Yield;
                 if (yield_.value) {
                     this.visitExpr(yield_.value);
                 }
@@ -1113,29 +421,29 @@ export class SymbolTable {
             }
             case ASTKind.YieldFrom:
                 assert(this.cur !== null);
-                this.visitExpr((e as YieldFrom).value);
+                this.visitExpr((e as astnode.YieldFrom).value);
                 this.cur.generator = true;
                 break;
             case ASTKind.Await:
                 assert(this.cur !== null);
-                this.visitExpr((e as Await).value);
+                this.visitExpr((e as astnode.Await).value);
                 this.cur.coroutine = true;
                 break;
             case ASTKind.Compare: {
-                const compare = e as Compare;
+                const compare = e as astnode.Compare;
                 this.visitExpr(compare.left);
                 this.SEQ(this.visitExpr, compare.comparators);
                 break;
             }
             case ASTKind.Call: {
-                const call = e as Call;
+                const call = e as astnode.Call;
                 this.visitExpr(call.func);
                 this.SEQ(this.visitExpr, call.args);
                 this.SEQ(this.visitKeyword, call.keywords);
                 break;
             }
             case ASTKind.FormattedValue: {
-                const formattedValue = e as FormattedValue;
+                const formattedValue = e as astnode.FormattedValue;
                 this.visitExpr(formattedValue.value);
                 if (formattedValue.format_spec) {
                     this.visitExpr(formattedValue.format_spec);
@@ -1143,7 +451,7 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.JoinedStr: {
-                this.SEQ(this.visitExpr, (e as JoinedStr).values);
+                this.SEQ(this.visitExpr, (e as astnode.JoinedStr).values);
                 break;
             }
             case ASTKind.Constant:
@@ -1151,19 +459,19 @@ export class SymbolTable {
                 break;
             /* The following exprs can be assignment targets. */
             case ASTKind.Attribute:
-                this.visitExpr((e as Attribute).value);
+                this.visitExpr((e as astnode.Attribute).value);
                 break;
             case ASTKind.Subscript: {
-                const subscript = e as Subscript;
+                const subscript = e as astnode.Subscript;
                 this.visitExpr(subscript.value);
                 this.visitExpr(subscript.slice);
                 break;
             }
             case ASTKind.Starred:
-                this.visitExpr((e as Starred).value);
+                this.visitExpr((e as astnode.Starred).value);
                 break;
             case ASTKind.Slice: {
-                const slice = e as Slice;
+                const slice = e as astnode.Slice;
                 if (slice.lower) {
                     this.visitExpr(slice.lower);
                 }
@@ -1177,7 +485,7 @@ export class SymbolTable {
             }
             case ASTKind.Name: {
                 assert(this.cur);
-                const name = e as Name;
+                const name = e as astnode.Name;
                 this.addDef(name.id, name.ctx === Load ? SYMTAB_CONSTS.USE : SYMTAB_CONSTS.DEF_LOCAL);
                 /* Special-case super: it counts as a use of __class__ */
                 if (name.ctx === Load && this.cur.blockType === BlockType.FunctionBlock && name.id === "super") {
@@ -1187,21 +495,21 @@ export class SymbolTable {
             }
             /* child nodes of List and Tuple will have expr_context set */
             case ASTKind.List:
-                this.SEQ(this.visitExpr, (e as List).elts);
+                this.SEQ(this.visitExpr, (e as astnode.List).elts);
                 break;
             case ASTKind.Tuple:
-                this.SEQ(this.visitExpr, (e as Tuple).elts);
+                this.SEQ(this.visitExpr, (e as astnode.Tuple).elts);
                 break;
         }
     }
 
-    visitParams(args: arg[]) {
+    visitParams(args: astnode.arg[]) {
         for (const a of args) {
             this.addDef(a.arg, SYMTAB_CONSTS.DEF_PARAM);
         }
     }
 
-    visitArguments(a: arguments_) {
+    visitArguments(a: astnode.arguments_) {
         /* skip default arguments inside function block
         XXX should ast be different?
         */
@@ -1229,7 +537,7 @@ export class SymbolTable {
         }
     }
 
-    visitArgannotations(args: arg[]) {
+    visitArgannotations(args: astnode.arg[]) {
         for (const a of args) {
             if (a.annotation) {
                 this.visitExpr(a.annotation);
@@ -1237,7 +545,7 @@ export class SymbolTable {
         }
     }
 
-    visitAnnotation(annotation: expr) {
+    visitAnnotation(annotation: astnode.expr) {
         // int future_annotations = st->st_future->ff_features & CO_FUTURE_ANNOTATIONS;
         // if (future_annotations &&
         //     !symtable_enter_block(st, GET_IDENTIFIER(_annotation), AnnotationBlock,
@@ -1252,7 +560,7 @@ export class SymbolTable {
         // }
     }
 
-    visitAnnotations(a: arguments_, returns: expr | null) {
+    visitAnnotations(a: astnode.arguments_, returns: astnode.expr | null) {
         // int future_annotations = st->st_future->ff_features & CO_FUTURE_ANNOTATIONS;
         // if (future_annotations &&
         //     !symtable_enter_block(st, GET_IDENTIFIER(_annotation), AnnotationBlock,
@@ -1289,7 +597,7 @@ export class SymbolTable {
         return this.cur.getSymbol(mangled);
     }
 
-    visitAlias(a: alias) {
+    visitAlias(a: astnode.alias) {
         /* Compute storeName, the name actually bound by the import
            operation.  It is different than a->name when a->name is a
            dotted package name (e.g. spam.eggs)
@@ -1318,14 +626,14 @@ export class SymbolTable {
         }
     }
 
-    visitWithItem(item: withitem) {
+    visitWithItem(item: astnode.withitem) {
         this.visitExpr(item.context_expr);
         if (item.optional_vars) {
             this.visitExpr(item.optional_vars);
         }
     }
 
-    visitExcepthandler(eh: ExceptHandler) {
+    visitExcepthandler(eh: astnode.ExceptHandler) {
         if (eh.type) {
             this.visitExpr(eh.type);
         }
@@ -1335,11 +643,11 @@ export class SymbolTable {
         this.SEQ(this.visitStmt, eh.body);
     }
 
-    visitStmt(s: stmt) {
+    visitStmt(s: astnode.stmt) {
         assert(s !== undefined, "visitStmt called with undefined");
         switch (s._kind) {
             case ASTKind.FunctionDef: {
-                const funcDef = s as FunctionDef;
+                const funcDef = s as astnode.FunctionDef;
                 this.addDef(funcDef.name, SYMTAB_CONSTS.DEF_LOCAL);
                 if (funcDef.args.defaults.length !== 0) {
                     this.SEQ(this.visitExpr, funcDef.args.defaults);
@@ -1355,7 +663,7 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.ClassDef: {
-                const classDef = s as ClassDef;
+                const classDef = s as astnode.ClassDef;
                 this.addDef(classDef.name, SYMTAB_CONSTS.DEF_LOCAL);
                 this.SEQ(this.visitExpr, classDef.bases);
                 this.SEQ(this.visitKeyword, classDef.keywords);
@@ -1380,7 +688,7 @@ export class SymbolTable {
             }
             case ASTKind.Return: {
                 assert(this.cur);
-                const return_ = s as Return;
+                const return_ = s as astnode.Return;
                 if (return_.value) {
                     this.visitExpr(return_.value);
                     this.cur.returnsValue = true;
@@ -1388,19 +696,19 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.Delete:
-                this.SEQ(this.visitExpr, (s as Delete).targets);
+                this.SEQ(this.visitExpr, (s as astnode.Delete).targets);
                 break;
             case ASTKind.Assign: {
-                const assign = s as Assign;
+                const assign = s as astnode.Assign;
                 this.SEQ(this.visitExpr, assign.targets);
                 this.visitExpr(assign.value);
                 break;
             }
             case ASTKind.AnnAssign: {
-                const annAssign = s as AnnAssign;
+                const annAssign = s as astnode.AnnAssign;
                 if (annAssign.target._kind === ASTKind.Name) {
                     assert(this.cur);
-                    const eName = annAssign.target as Name;
+                    const eName = annAssign.target as astnode.Name;
                     const cur = this.lookup(eName.id);
                     if (
                         cur & (SYMTAB_CONSTS.DEF_GLOBAL | SYMTAB_CONSTS.DEF_NONLOCAL) &&
@@ -1431,14 +739,14 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.AugAssign: {
-                const augAssign = s as AugAssign;
+                const augAssign = s as astnode.AugAssign;
 
                 this.visitExpr(augAssign.target);
                 this.visitExpr(augAssign.value);
                 break;
             }
             case ASTKind.For: {
-                const for_ = s as For;
+                const for_ = s as astnode.For;
 
                 this.visitExpr(for_.target);
                 this.visitExpr(for_.iter);
@@ -1449,7 +757,7 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.While: {
-                const while_ = s as While;
+                const while_ = s as astnode.While;
 
                 this.visitExpr(while_.test);
                 this.SEQ(this.visitStmt, while_.body);
@@ -1459,7 +767,7 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.If: {
-                const if_ = s as If;
+                const if_ = s as astnode.If;
 
                 /* XXX if 0: and lookup_yield() hacks */
                 this.visitExpr(if_.test);
@@ -1470,7 +778,7 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.Raise: {
-                const raise = s as Raise;
+                const raise = s as astnode.Raise;
 
                 if (raise.exc) {
                     this.visitExpr(raise.exc);
@@ -1481,19 +789,19 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.Try: {
-                const try_ = s as Try;
+                const try_ = s as astnode.Try;
 
                 this.SEQ(this.visitStmt, try_.body);
                 this.SEQ(this.visitStmt, try_.orelse);
                 this.SEQ(
                     this.visitExcepthandler,
-                    try_.handlers as ExceptHandler[]
+                    try_.handlers as astnode.ExceptHandler[]
                 ); /** @todo Update adsl to make `handlers` of type ExceptHandler[] */
                 this.SEQ(this.visitStmt, try_.finalbody);
                 break;
             }
             case ASTKind.Assert: {
-                const assert = s as Assert;
+                const assert = s as astnode.Assert;
                 this.visitExpr(assert.test);
                 if (assert.msg) {
                     this.visitExpr(assert.msg);
@@ -1501,17 +809,17 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.Import: {
-                const import_ = s as Import;
+                const import_ = s as astnode.Import;
                 this.SEQ(this.visitAlias, import_.names);
                 break;
             }
             case ASTKind.ImportFrom: {
-                const importFrom = s as ImportFrom;
+                const importFrom = s as astnode.ImportFrom;
                 this.SEQ(this.visitAlias, importFrom.names);
                 break;
             }
             case ASTKind.Global: {
-                const global = s as Global;
+                const global = s as astnode.Global;
 
                 for (const name of global.names) {
                     const cur = this.lookup(name);
@@ -1541,7 +849,7 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.Nonlocal: {
-                const nonlolal = s as Nonlocal;
+                const nonlolal = s as astnode.Nonlocal;
 
                 for (const name of nonlolal.names) {
                     const cur = this.lookup(name);
@@ -1571,7 +879,7 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.Expr: {
-                this.visitExpr((s as Expr).value);
+                this.visitExpr((s as astnode.Expr).value);
                 break;
             }
             case ASTKind.Pass:
@@ -1580,14 +888,14 @@ export class SymbolTable {
                 /* nothing to do here */
                 break;
             case ASTKind.With: {
-                const with_ = s as With;
+                const with_ = s as astnode.With;
                 this.SEQ(this.visitWithItem, with_.items);
                 this.SEQ(this.visitStmt, with_.body);
                 break;
             }
             case ASTKind.AsyncFunctionDef: {
                 assert(this.cur);
-                const asyncFunctionDef = s as AsyncFunctionDef;
+                const asyncFunctionDef = s as astnode.AsyncFunctionDef;
 
                 this.addDef(asyncFunctionDef.name, SYMTAB_CONSTS.DEF_LOCAL);
                 if (asyncFunctionDef.args.defaults.length !== 0) {
@@ -1598,8 +906,9 @@ export class SymbolTable {
                 }
                 this.visitAnnotations(asyncFunctionDef.args, asyncFunctionDef.returns);
 
-                if (asyncFunctionDef.decorator_list.length !== 0)
+                if (asyncFunctionDef.decorator_list.length !== 0) {
                     this.SEQ(this.visitExpr, asyncFunctionDef.decorator_list);
+                }
 
                 this.enterBlock(
                     asyncFunctionDef.name,
@@ -1617,17 +926,19 @@ export class SymbolTable {
                 break;
             }
             case ASTKind.AsyncWith: {
-                const asyncWith = s as AsyncWith;
+                const asyncWith = s as astnode.AsyncWith;
                 this.SEQ(this.visitWithItem, asyncWith.items);
                 this.SEQ(this.visitStmt, asyncWith.body);
                 break;
             }
             case ASTKind.AsyncFor: {
-                const asyncFor = s as AsyncFor;
+                const asyncFor = s as astnode.AsyncFor;
                 this.visitExpr(asyncFor.target);
                 this.visitExpr(asyncFor.iter);
                 this.SEQ(this.visitStmt, asyncFor.body);
-                if (asyncFor.orelse.length !== 0) this.SEQ(this.visitStmt, asyncFor.orelse);
+                if (asyncFor.orelse.length !== 0) {
+                    this.SEQ(this.visitStmt, asyncFor.orelse);
+                }
                 break;
             }
             default:
@@ -1641,33 +952,4 @@ export class SymbolTable {
         const global = new Set<string>();
         this.top.analyzeBlock(null, free, global);
     }
-}
-
-// deno-lint-ignore no-explicit-any
-export function buildSymbolTable(mod: mod, filename: string, future: any): SymbolTable {
-    const st = new SymbolTable(filename, future);
-    /* Make the initial symbol information gathering pass */
-    st.enterBlock("top", BlockType.ModuleBlock, mod, 0, 0);
-    st.top = st.cur;
-    switch (mod._kind) {
-        case ASTKind.Module: {
-            st.SEQ(st.visitStmt, (mod as Module).body);
-            break;
-        }
-        case ASTKind.Expression: {
-            st.visitExpr((mod as Expression).body);
-            break;
-        }
-        case ASTKind.Interactive: {
-            st.SEQ(st.visitStmt, (mod as Interactive).body);
-            break;
-        }
-        case ASTKind.FunctionType:
-            throw new Error("this compiler does not handle FunctionTypes");
-    }
-    st.exitBlock();
-    /* Make the second symbol analysis pass */
-    st.analyze();
-
-    return st;
 }

--- a/src/symtable/SymbolTableScope.ts
+++ b/src/symtable/SymbolTableScope.ts
@@ -1,0 +1,455 @@
+import type { AST } from "../ast/astnodes.ts";
+import { pySyntaxError } from "../ast/errors.ts";
+import { assert } from "../parser/pegen.ts";
+import type { SymbolTable } from "./SymbolTable.ts";
+import { Symbol_ } from "./Symbol.ts";
+import { BlockType, SYMTAB_CONSTS, inplaceMerge } from "./util.ts";
+
+let astScopeCounter = 0;
+
+export class SymbolTableScope {
+    name: string;
+    varnames: string[];
+    children: SymbolTableScope[] | null;
+    blockType: BlockType;
+    isNested = false;
+    hasFree: boolean;
+    childHasFree: boolean;
+    generator: boolean;
+    varargs: boolean;
+    varkeywords: boolean;
+    returnsValue: boolean;
+    filename: string;
+    lineno: number;
+    colOffset: number;
+    endLineno: number | null | undefined;
+    endColOffset: number | null | undefined;
+    table: SymbolTable;
+    symbols: { [name: string]: number };
+    _funcLocals: string[] | null = null;
+    _funcParams: string[] | null = null;
+    _funcGlobals: string[] | null = null;
+    _funcNonlocals: string[] | null = null;
+    _funcFrees: string[] | null = null;
+    _classMethods: string[] | null = null;
+    comp_iter_expr = 0;
+    comp_iter_target = false;
+    comprehension = false;
+    directives: [string, number, number][] | null = null;
+    coroutine = false;
+    needs_class_closure = false;
+
+    constructor(
+        table: SymbolTable,
+        name: string,
+        type: BlockType,
+        ast: AST,
+        filename: string,
+        lineno: number,
+        colOffset: number,
+        endLineno?: number | null,
+        endColOffset?: number | null
+    ) {
+        this.name = name;
+        this.varnames = [];
+        this.children = null;
+        this.blockType = type;
+
+        this.isNested = false;
+        this.hasFree = false;
+        this.childHasFree = false; // true if child block has free vars including free refs to globals
+        this.generator = false;
+        this.varargs = false;
+        this.varkeywords = false;
+        this.returnsValue = false;
+
+        this.filename = filename;
+        this.lineno = lineno;
+        this.colOffset = colOffset;
+        this.endLineno = endLineno;
+        this.endColOffset = endColOffset;
+
+        this.table = table;
+
+        if (table.cur && (table.cur.isNested || table.cur.blockType === BlockType.FunctionBlock)) {
+            this.isNested = true;
+        }
+
+        ast.scopeId = astScopeCounter++;
+        table.stss[ast.scopeId] = this;
+
+        // cache of Symbols for returning to other parts of code
+        this.symbols = {};
+    }
+
+    get_type() {
+        return this.blockType;
+    }
+
+    get_name() {
+        return this.name;
+    }
+
+    get_lineno() {
+        return this.lineno;
+    }
+
+    is_nested() {
+        return this.isNested;
+    }
+
+    has_children() {
+        return !!(this.children && this.children.length > 0);
+    }
+
+    get_children() {
+        return this.children || [];
+    }
+
+    get_identifiers() {
+        return this._identsMatching(function () {
+            return true;
+        });
+    }
+
+    getSymbol(name: string): number {
+        return this.symbols[name];
+    }
+
+    lookup(name: string): Symbol_ {
+        return new Symbol_(name, this.symbols[name], this.__check_children(name), this.name === "top");
+        // let sym;
+        // if (!(name in this.symbols)) {
+        //     const flags = this.symFlags[name];
+        //     const namespaces = this.__check_children(name);
+        //     sym = this.symbols[name] = new Symbol_(name, flags, namespaces);
+        // } else {
+        //     sym = this.symbols[name];
+        // }
+        // return sym;
+    }
+
+    __check_children(name: string): SymbolTableScope[] | null {
+        if (this.children) {
+            return this.children.filter((c) => c.name === name);
+        }
+
+        return null;
+    }
+
+    _identsMatching(f: (flag: number) => boolean): string[] {
+        return Object.entries(this.symbols)
+            .filter(([_, v]) => f(v))
+            .map(([k, _]) => k);
+    }
+
+    get_parameters(): string[] {
+        assert(this.get_type() === "function", "get_parameters only valid for function scopes");
+        if (this._funcParams === null) {
+            this._funcParams = this._identsMatching((x) => !!(x & SYMTAB_CONSTS.DEF_PARAM));
+        }
+        return this._funcParams;
+    }
+
+    get_locals(): string[] {
+        if (this._funcLocals === null) {
+            const locs = [SYMTAB_CONSTS.LOCAL, SYMTAB_CONSTS.CELL];
+            const test = (x: number) => locs.includes((x >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK);
+            this._funcLocals = this._identsMatching(test);
+        }
+        return this._funcLocals;
+    }
+
+    get_globals(): string[] {
+        assert(this.get_type() === "function", "get_globals only valid for function scopes");
+        if (this._funcGlobals === null) {
+            this._funcGlobals = this._identsMatching(function (x) {
+                const masked = (x >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK;
+                return masked === SYMTAB_CONSTS.GLOBAL_IMPLICIT || masked === SYMTAB_CONSTS.GLOBAL_EXPLICIT;
+            });
+        }
+        return this._funcGlobals;
+    }
+
+    get_nonlocals(): string[] {
+        if (this._funcNonlocals === null) {
+            this._funcNonlocals = this._identsMatching((x) => !!(x & SYMTAB_CONSTS.DEF_NONLOCAL));
+        }
+        return this._funcNonlocals;
+    }
+
+    get_frees(): string[] {
+        assert(this.get_type() === "function", "get_frees only valid for function scopes");
+        if (this._funcFrees === null) {
+            this._funcFrees = this._identsMatching(function (x) {
+                const masked = (x >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK;
+                return masked === SYMTAB_CONSTS.FREE;
+            });
+        }
+        return this._funcFrees;
+    }
+
+    get_methods() {
+        assert(this.get_type() === "class", "get_methods only valid for class scopes");
+        if (this._classMethods === null) {
+            this._classMethods = this.children?.map((c) => c.name) ?? [];
+        }
+        return this._classMethods;
+    }
+
+    get_scope(name: string): number {
+        const v = this.symbols[name];
+        if (v === undefined) {
+            return 0;
+        }
+        return (v >> SYMTAB_CONSTS.SCOPE_OFFSET) & SYMTAB_CONSTS.SCOPE_MASK;
+    }
+
+    dropClassFree(free: Set<string>) {
+        free.delete("__class__");
+
+        this.needs_class_closure = true;
+    }
+
+    errorAtDirective(name: string, errorMessage: string): never {
+        assert(this.directives);
+        for (const [directiveName, lineno, colOffset] of this.directives) {
+            if (directiveName === name) {
+                throw new pySyntaxError(errorMessage, [this.filename, lineno, colOffset, ""]);
+            }
+        }
+
+        throw new Error("BUG: internal directive bookkeeping broken");
+    }
+
+    /* Decide on scope of name, given flags.
+    The namespace dictionaries may be modified to record information
+    about the new name.  For example, a new global will add an entry to
+    global.  A name that was global can be changed to local.
+    */
+    analyzeName(
+        scopes: { [name: string]: number },
+        name: string,
+        flags: number,
+        bound: Set<string> | null,
+        local: Set<string>,
+        free: Set<string>,
+        global: Set<string>
+    ) {
+        if (flags & SYMTAB_CONSTS.DEF_GLOBAL) {
+            if (flags & SYMTAB_CONSTS.DEF_NONLOCAL) {
+                this.errorAtDirective(name, `name '${name}' is nonlocal and global`);
+            }
+            scopes[name] = SYMTAB_CONSTS.GLOBAL_EXPLICIT;
+            global.add(name);
+            if (bound) {
+                bound.delete(name);
+            }
+            return;
+        }
+
+        if (flags & SYMTAB_CONSTS.DEF_NONLOCAL) {
+            if (bound === null) {
+                this.errorAtDirective(name, "nonlocal declaration not allowed at module level");
+            }
+            if (bound.has(name)) {
+                this.errorAtDirective(name, `no binding for nonlocal '${name}' found`);
+            }
+            scopes[name] = SYMTAB_CONSTS.FREE;
+            this.hasFree = true;
+            free.add(name);
+            return;
+        }
+
+        if (flags & SYMTAB_CONSTS.DEF_BOUND) {
+            scopes[name] = SYMTAB_CONSTS.LOCAL;
+            local.add(name);
+            global.delete(name);
+            return;
+        }
+
+        /* If an enclosing block has a binding for this name, it
+        is a free variable rather than a global variable.
+        Note that having a non-NULL bound implies that the block
+        is nested.
+        */
+        if (bound && bound.has(name)) {
+            scopes[name] = SYMTAB_CONSTS.FREE;
+            this.hasFree = true;
+            free.add(name);
+            return;
+        }
+
+        /* If a parent has a global statement, then call it global
+        explicit?  It could also be global implicit.
+        */
+
+        if (global.has(name)) {
+            scopes[name] = SYMTAB_CONSTS.GLOBAL_IMPLICIT;
+            return;
+        }
+
+        if (this.isNested) {
+            this.hasFree = true;
+        }
+
+        scopes[name] = SYMTAB_CONSTS.GLOBAL_IMPLICIT;
+    }
+
+    analyzeChildBlock(bound: Set<string>, free: Set<string>, global: Set<string>, childFree: Set<string>) {
+        /* Copy the bound and global dictionaries.
+        These dictionaries are used by all blocks enclosed by the
+        current block.  The analyze_block() call modifies these
+        dictionaries.
+        */
+        const tempBound = new Set(bound);
+        const tempFree = new Set(free);
+        const tempGlobal = new Set(global);
+
+        this.analyzeBlock(tempBound, tempFree, tempGlobal);
+
+        inplaceMerge(childFree, tempFree);
+    }
+
+    analyzeCells(scopes: { [name: string]: number }, free: Set<string>) {
+        for (const [name, scope] of Object.entries(scopes)) {
+            if (scope !== SYMTAB_CONSTS.LOCAL) {
+                continue;
+            }
+
+            if (!free.has(name)) {
+                continue;
+            }
+            /* Replace LOCAL with CELL for this name, and remove
+            from free. It is safe to replace the value of name
+            in the dict, because it will not cause a resize.
+            */
+            scopes[name] = SYMTAB_CONSTS.CELL;
+            free.delete(name);
+        }
+    }
+
+    updateSymbols(
+        scopes: { [name: string]: number },
+        bound: Set<string> | null,
+        free: Set<string>,
+        classFlag: boolean
+    ) {
+        /* Update scope information for all symbols in this scope */
+        for (let [name, flags] of Object.entries(this.symbols)) {
+            flags |= scopes[name] << SYMTAB_CONSTS.SCOPE_OFFSET;
+            this.symbols[name] = flags;
+        }
+
+        /* Record not yet resolved free variables from children (if any) */
+        const vFree = SYMTAB_CONSTS.FREE << SYMTAB_CONSTS.SCOPE_OFFSET;
+
+        for (const name in free) {
+            const v = this.symbols[name];
+
+            /* Handle symbol that already exists in this scope */
+            if (v) {
+                /* Handle a free variable in a method of
+                   the class that has the same name as a local
+                   or global in the class scope.
+                */
+                if (classFlag && v & (SYMTAB_CONSTS.DEF_BOUND | SYMTAB_CONSTS.DEF_GLOBAL)) {
+                    const flags = v | SYMTAB_CONSTS.DEF_FREE_CLASS;
+                    this.symbols[name] = flags;
+                }
+                /* It's a cell, or already free in this scope */
+                continue;
+            }
+            /* Handle global symbol */
+            if (bound && !bound.has(name)) {
+                continue; /* it's a global */
+            }
+            /* Propagate new free symbol up the lexical stack */
+            this.symbols[name] = vFree;
+        }
+    }
+
+    analyzeBlock(bound: Set<string> | null, free: Set<string>, global: Set<string>) {
+        const local = new Set<string>(); /* collect new names bound in block */
+
+        const scopes = {}; /* collect scopes defined for each name */
+
+        /* Allocate new global and bound variable dictionaries.  These
+        dictionaries hold the names visible in nested blocks.  For
+        BlockType.ClassBlocks, the bound and global names are initialized
+        before analyzing names, because class bindings aren't
+        visible in methods.  For other blocks, they are initialized
+        after names are analyzed.
+        */
+
+        /* TODO(jhylton): Package these dicts in a struct so that we
+        can write reasonable helper functions?
+        */
+        const newglobal = new Set<string>();
+        const newfree = new Set<string>();
+        const newbound = new Set<string>();
+
+        /* Class namespace has no effect on names visible in
+        nested functions, so populate the global and bound
+        sets to be passed to child blocks before analyzing
+        this one.
+        */
+        if (this.blockType === BlockType.ClassBlock) {
+            /* Pass down known globals */
+            inplaceMerge(newglobal, global);
+
+            /* Pass down previously bound symbols */
+            if (bound) {
+                inplaceMerge(newbound, bound);
+            }
+        }
+
+        for (const [name, flags] of Object.entries(this.symbols)) {
+            this.analyzeName(scopes, name, flags, bound, local, free, global);
+        }
+
+        /* Populate global and bound sets to be passed to children. */
+        if (this.blockType !== BlockType.ClassBlock) {
+            /* Add function locals to bound set */
+            if (this.blockType === BlockType.FunctionBlock) {
+                inplaceMerge(newbound, local);
+            }
+            /* Pass down previously bound symbols */
+            if (bound) {
+                inplaceMerge(newbound, bound);
+            }
+            /* Pass down known globals */
+            inplaceMerge(newglobal, global);
+        } else {
+            /* Special-case __class__ */
+            newbound.add("__class__");
+        }
+
+        /* Recursively call analyze_child_block() on each child block.
+        newbound, newglobal now contain the names visible in
+        nested blocks.  The free variables in the children will
+        be collected in allfree.
+        */
+        const allfree = new Set<string>();
+        for (const entry of this.children || []) {
+            entry.analyzeChildBlock(newbound, newfree, newglobal, allfree);
+            if (entry.hasFree || entry.childHasFree) {
+                this.childHasFree = true;
+            }
+        }
+
+        inplaceMerge(newfree, allfree);
+
+        /* Check if any local variables must be converted to cell variables */
+        if (this.blockType === BlockType.FunctionBlock) {
+            this.analyzeCells(scopes, newfree);
+        } else if (this.blockType === BlockType.ClassBlock) {
+            this.dropClassFree(newfree);
+        }
+
+        /* Records the results of the analysis in the symbol table entry */
+        this.updateSymbols(scopes, bound, newfree, this.blockType === BlockType.ClassBlock);
+
+        inplaceMerge(free, newfree);
+    }
+}

--- a/src/symtable/mod.ts
+++ b/src/symtable/mod.ts
@@ -1,0 +1,37 @@
+import type { Module, Expression, Interactive, mod } from "../ast/astnodes.ts";
+import { ASTKind } from "../ast/astnodes.ts";
+import { SymbolTable } from "./SymbolTable.ts";
+import { BlockType } from "./util.ts";
+
+export { SymbolTable, BlockType };
+export type { Symbol_ } from "./Symbol.ts";
+export type { SymbolTableScope } from "./SymbolTableScope.ts";
+
+// deno-lint-ignore no-explicit-any
+export function buildSymbolTable(mod: mod, filename: string, future: any): SymbolTable {
+    const st = new SymbolTable(filename, future);
+    /* Make the initial symbol information gathering pass */
+    st.enterBlock("top", BlockType.ModuleBlock, mod, 0, 0);
+    st.top = st.cur;
+    switch (mod._kind) {
+        case ASTKind.Module: {
+            st.SEQ(st.visitStmt, (mod as Module).body);
+            break;
+        }
+        case ASTKind.Expression: {
+            st.visitExpr((mod as Expression).body);
+            break;
+        }
+        case ASTKind.Interactive: {
+            st.SEQ(st.visitStmt, (mod as Interactive).body);
+            break;
+        }
+        case ASTKind.FunctionType:
+            throw new Error("this compiler does not handle FunctionTypes");
+    }
+    st.exitBlock();
+    /* Make the second symbol analysis pass */
+    st.analyze();
+
+    return st;
+}

--- a/src/symtable/util.ts
+++ b/src/symtable/util.ts
@@ -1,0 +1,70 @@
+export enum BlockType {
+    ModuleBlock = "module",
+    FunctionBlock = "function",
+    ClassBlock = "class",
+    AnnotationBlock = "annotation",
+}
+
+export function inplaceMerge<T>(left: Set<T>, right: Set<T>) {
+    for (const v of right) {
+        left.add(v);
+    }
+}
+
+const LEADING_UNDERSCORE_REGEX = /^_+/;
+
+export enum SYMTAB_CONSTS {
+    DEF_GLOBAL = 1 /* global stmt */,
+    DEF_LOCAL = 2 /* assignment in code block */,
+    DEF_PARAM = 2 << 1 /* formal parameter */,
+    DEF_NONLOCAL = 2 << 2 /* nonlocal stmt */,
+    USE = 2 << 3 /* name is used */,
+    DEF_FREE = 2 << 4 /* name used but not defined in nested block */,
+    DEF_FREE_CLASS = 2 << 5 /* free variable from class's method */,
+    DEF_IMPORT = 2 << 6 /* assignment occurred via import */,
+    DEF_ANNOT = 2 << 7 /* this name is annotated */,
+    DEF_COMP_ITER = 2 << 8 /* this name is a comprehension iteration variable */,
+    DEF_BOUND = DEF_LOCAL | DEF_PARAM | DEF_IMPORT,
+
+    /* GLOBAL_EXPLICIT and GLOBAL_IMPLICIT are used internally by the symbol
+       table.  GLOBAL is returned from PyST_GetScope() for either of them.
+       It is stored in ste_symbols at bits 12-15.
+    */
+
+    SCOPE_OFFSET = 11,
+    SCOPE_MASK = DEF_GLOBAL | DEF_LOCAL | DEF_PARAM | DEF_NONLOCAL,
+    LOCAL = 1,
+    GLOBAL_EXPLICIT = 2,
+    GLOBAL_IMPLICIT = 3,
+    FREE = 4,
+    CELL = 5,
+    GENERATOR = 1,
+    GENERATOR_EXPRESSION = 2,
+}
+
+export function mangle(privateobj: string | null, ident: string) {
+    /* Name mangling: __private becomes _classname__private.
+       This is independent from how the name is used. */
+    if (privateobj === null /* !PyUnicode_Check(privateobj) || */ || !ident.startsWith("__")) {
+        return ident;
+    }
+    /* Don't mangle __id__ or names with dots.
+          The only time a name with a dot can occur is when
+          we are compiling an import statement that has a
+          package name.
+          TODO(jhylton): Decide whether we want to support
+          mangling of the module name, e.g. __M.X.
+       */
+    if (ident.endsWith("__") || ident.includes(".")) {
+        return ident; /* Don't mangle __whatever__ */
+    }
+
+    /* Strip leading underscores from class name */
+    const stripped = privateobj.replace(LEADING_UNDERSCORE_REGEX, "");
+    if (stripped.length === 0) {
+        return ident; /* Don't mangle if class is just underscores */
+    }
+
+    /* ident = "_" + priv[ipriv:] + ident # i.e. 1+plen+nlen bytes */
+    return `_${stripped}${ident}`;
+}

--- a/support/symtable_dump.ts
+++ b/support/symtable_dump.ts
@@ -1,5 +1,6 @@
 import { assert } from "../src/parser/pegen.ts";
-import { SymbolTableScope, Symbol_, BlockType, SymbolTable } from "../src/parser/symtable.ts";
+import type { SymbolTableScope, Symbol_, SymbolTable } from "../src/symtable/mod.ts";
+import { BlockType } from "../src/symtable/mod.ts";
 
 type Table = { [s: string]: boolean | BlockType | string | number | string[] | Table[] | null };
 

--- a/tests/symtable.tests.ts
+++ b/tests/symtable.tests.ts
@@ -1,6 +1,6 @@
 import { dump } from "../support/symtable_dump.ts";
 import { getPySymTableDump } from "../support/py_symtable_dump.ts";
-import { buildSymbolTable } from "../src/parser/symtable.ts";
+import { buildSymbolTable } from "../src/symtable/mod.ts";
 
 import { runParserFromString } from "../src/parser/parse.ts";
 import { runTests } from "./run_tests_helper.ts";


### PR DESCRIPTION
In some astnode constructors we set the attribute to an empty list where cpython uses null.
e.g. `decorator_list`.
So those checks were always truthy. I replaced those checks with `decorator_list.length !== 0`


`append` - we can just iterate over the set rather than calling its values.
I also changed the name to `inplaceMerge` just because.

