### PR TITLE
errors

### DIFF
--- a/src/ast/errors.ts
+++ b/src/ast/errors.ts
@@ -7,21 +7,14 @@ type offset = number;
 type text = string;
 
 export class pySyntaxError extends SyntaxError {
-    static _name = "SyntaxError";
+    name = "SyntaxError";
     traceback: [filename, lineno, offset, text];
     constructor(msg: string, traceback: [filename, lineno, offset, text]) {
         super(msg);
         this.traceback = traceback;
     }
-    get [Symbol.toStringTag]() {
-        return (this.constructor as typeof pySyntaxError)._name;
-    }
-    get name() {
-        // so that we display nicer error messages internally by default
-        return (this.constructor as typeof pySyntaxError)._name;
-    }
 }
 
 export class pyIndentationError extends pySyntaxError {
-    static _name = "IndentationError";
+    name = "IndentationError";
 }


### PR DESCRIPTION
We'll also need to find a way to re-throw these

using the name property of an error seems sensible so it makes sense just to put the `name` on the instance.