### PR TITLE
Symtable perf

### DIFF
--- a/src/symtable/SymbolTable.ts
+++ b/src/symtable/SymbolTable.ts
@@ -87,7 +87,7 @@ export class SymbolTable {
     }
 
     SEQ<T>(visitor: (node: T) => void, nodes: (T | null)[]) {
-        assert(Array.isArray(nodes), "SEQ: nodes isn't array? got " + nodes.toString());
+        assert(Array.isArray(nodes), "SEQ: nodes isn't array? got " + typeof nodes);
         for (const node of nodes) {
             if (node) {
                 visitor.call(this, node);

--- a/src/symtable/SymbolTableScope.ts
+++ b/src/symtable/SymbolTableScope.ts
@@ -302,9 +302,9 @@ export class SymbolTableScope {
         current block.  The analyze_block() call modifies these
         dictionaries.
         */
-        const tempBound = new Set(bound);
-        const tempFree = new Set(free);
-        const tempGlobal = new Set(global);
+        const tempBound = new Set([...bound]);
+        const tempFree = new Set([...free]);
+        const tempGlobal = new Set([...global]);
 
         this.analyzeBlock(tempBound, tempFree, tempGlobal);
 

--- a/src/symtable/SymbolTableScope.ts
+++ b/src/symtable/SymbolTableScope.ts
@@ -138,9 +138,14 @@ export class SymbolTableScope {
     }
 
     private identsMatching(f: (flag: number) => boolean): string[] {
-        return Object.entries(this.symbols)
-            .filter(([_, v]) => f(v))
-            .map(([k, _]) => k);
+        const idents = [];
+        for (const name in this.symbols) {
+            const flags = this.symbols[name];
+            if (f(flags)) {
+                idents.push(name);
+            }
+        }
+        return idents;
     }
 
     get_parameters(): string[] {
@@ -312,7 +317,8 @@ export class SymbolTableScope {
     }
 
     analyzeCells(scopes: NameToFlag, free: Set<string>) {
-        for (const [name, scope] of Object.entries(scopes)) {
+        for (const name in scopes) {
+            const scope = scopes[name];
             if (scope !== SYMTAB_CONSTS.LOCAL) {
                 continue;
             }
@@ -331,7 +337,8 @@ export class SymbolTableScope {
 
     updateSymbols(scopes: NameToFlag, bound: Set<string> | null, free: Set<string>, classFlag: boolean) {
         /* Update scope information for all symbols in this scope */
-        for (let [name, flags] of Object.entries(this.symbols)) {
+        for (const name in this.symbols) {
+            let flags = this.symbols[name];
             flags |= scopes[name] << SYMTAB_CONSTS.SCOPE_OFFSET;
             this.symbols[name] = flags;
         }
@@ -399,7 +406,8 @@ export class SymbolTableScope {
             }
         }
 
-        for (const [name, flags] of Object.entries(this.symbols)) {
+        for (const name in this.symbols) {
+            const flags = this.symbols[name];
             this.analyzeName(scopes, name, flags, bound, local, free, global);
         }
 


### PR DESCRIPTION
did some profiling
found a bug
The big win was not calling `toString()` in the first assert statement.

I also looked at changing `scope` and `symbols` into Maps. But I didn't commit that.
It's seems marginally better to use Maps because iteration with a Map is faster.
But then lookups and assignments seem slightly slower.
But it's probably not worth making them Maps for performance since that was very marginal gains.

Running the turtle.py `ast` 2000 times through `buildSymbolTable`

```
master
    2000 runs avg: 2.336626775499999ms
fastest 2.0527920000004087 
initial 15.092666999999892

this branch
    2000 runs avg: 1.2770894225000027ms
fastest 1.0512920000001031 
initial 12.497375000000147
```

It's also noticeable that esbuild doesn't convert const enums to their values in minified code.
https://esbuild.github.io/content-types/#no-type-system
So the switch case checks all took a bit more time then they needed to.
We'll want to make sure that's addressed in production eventually. #100 
Seems silly to do an enum lookup per switch case when we don't need to.