### PR TITLE
Cleanups

### DIFF
--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -12,7 +12,7 @@
  */
 import { bench, Colors, parse, runBenchmarks } from "../deps.ts";
 import type { expr, mod } from "../src/ast/astnodes.ts";
-import { runParserFromString } from "../src/parser/parse.ts";
+import { runParserFromString } from "../src/parser/mod.ts";
 import { buildSymbolTable } from "../src/symtable/mod.ts";
 import { readString } from "../src/tokenize/readline.ts";
 import { tokenize } from "../src/tokenize/tokenize.ts";

--- a/scripts/parse.ts
+++ b/scripts/parse.ts
@@ -5,7 +5,7 @@
 import { dump } from "../support/ast_dump.ts";
 import { parse } from "../deps.ts";
 import { getPyAstDump } from "../support/py_ast_dump.ts";
-import { runParserFromFile } from "../src/parser/parse.ts";
+import { runParserFromFile } from "../src/parser/mod.ts";
 import type { expr, mod } from "../src/ast/astnodes.ts";
 import { doCompare, getFileNameOrRunTest } from "./helpers.ts";
 import { switchVersion } from "../src/util/switch_version.ts";

--- a/scripts/symtable.ts
+++ b/scripts/symtable.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { parse } from "../deps.ts";
-import { runParserFromFile } from "../src/parser/parse.ts";
-import { buildSymbolTable } from "../src/symtable/mod.ts";
+import { symtableFromFile } from "../src/symtable/mod.ts";
 import { getPySymTableDump } from "../support/py_symtable_dump.ts";
 import { dump } from "../support/symtable_dump.ts";
 import { doCompare, getFileNameOrRunTest } from "./helpers.ts";
@@ -16,8 +15,7 @@ const argv = parse(Deno.args, {
 const { _: args, no_compare: noCompare } = argv;
 
 const filename = getFileNameOrRunTest(args);
-const ast = runParserFromFile(filename);
-const symbolTable = buildSymbolTable(ast, filename);
+const symbolTable = symtableFromFile(filename);
 
 if (noCompare) {
     console.log(symbolTable);

--- a/src/ast/astnodes.ts
+++ b/src/ast/astnodes.ts
@@ -104,7 +104,7 @@ AST.prototype._attributes = [];
 AST.prototype._fields = [];
 AST.prototype._enum = false;
 
-export type Attrs = [number, number, number | null | undefined, number | null | undefined];
+export type Attrs = [number, number, number, number];
 const _attrs = ["lineno", "col_offset", "end_lineno", "end_col_offset"];
 
 /* ---------------------- */
@@ -332,9 +332,9 @@ export class stmt extends AST {
     static _name = "stmt";
     lineno: number;
     col_offset: number;
-    end_lineno?: number | null;
-    end_col_offset?: number | null;
-    constructor(lineno: number, col_offset: number, end_lineno?: number | null, end_col_offset?: number | null) {
+    end_lineno: number;
+    end_col_offset: number;
+    constructor(lineno: number, col_offset: number, end_lineno: number, end_col_offset: number) {
         super();
         this.lineno = lineno;
         this.col_offset = col_offset;
@@ -758,9 +758,9 @@ export class expr extends AST {
     static _name = "expr";
     lineno: number;
     col_offset: number;
-    end_lineno?: number | null;
-    end_col_offset?: number | null;
-    constructor(lineno: number, col_offset: number, end_lineno?: number | null, end_col_offset?: number | null) {
+    end_lineno: number;
+    end_col_offset: number;
+    constructor(lineno: number, col_offset: number, end_lineno: number, end_col_offset: number) {
         super();
         this.lineno = lineno;
         this.col_offset = col_offset;
@@ -1152,9 +1152,9 @@ export class excepthandler extends AST {
     static _name = "excepthandler";
     lineno: number;
     col_offset: number;
-    end_lineno?: number | null;
-    end_col_offset?: number | null;
-    constructor(lineno: number, col_offset: number, end_lineno?: number | null, end_col_offset?: number | null) {
+    end_lineno: number;
+    end_col_offset: number;
+    constructor(lineno: number, col_offset: number, end_lineno: number, end_col_offset: number) {
         super();
         this.lineno = lineno;
         this.col_offset = col_offset;
@@ -1219,16 +1219,16 @@ export class arg extends AST {
     type_comment: string | null;
     lineno: number;
     col_offset: number;
-    end_lineno?: number | null;
-    end_col_offset?: number | null;
+    end_lineno: number;
+    end_col_offset: number;
     constructor(
         arg: identifier,
         annotation: expr | null,
         type_comment: string | null,
         lineno: number,
         col_offset: number,
-        end_lineno?: number | null,
-        end_col_offset?: number | null
+        end_lineno: number,
+        end_col_offset: number
     ) {
         super();
         this.arg = arg;
@@ -1251,15 +1251,15 @@ export class keyword extends AST {
     value: expr;
     lineno: number;
     col_offset: number;
-    end_lineno?: number | null;
-    end_col_offset?: number | null;
+    end_lineno: number;
+    end_col_offset: number;
     constructor(
         arg: identifier | null,
         value: expr,
         lineno: number,
         col_offset: number,
-        end_lineno?: number | null,
-        end_col_offset?: number | null
+        end_lineno: number,
+        end_col_offset: number
     ) {
         super();
         this.arg = arg;

--- a/src/parser/mod.ts
+++ b/src/parser/mod.ts
@@ -5,7 +5,7 @@ import { tokenizerFromFile, tokenizerFromString } from "../tokenize/mod.ts";
 import { GeneratedParser } from "./generated_parser.ts";
 import { StartRule } from "./pegen_types.ts";
 
-type ModeStr = "exec" | "eval" | "single";
+export type ModeStr = "exec" | "eval" | "single";
 
 function modeStrToStartRule(mode: ModeStr): StartRule {
     switch (mode) {
@@ -39,3 +39,6 @@ export function parserFromFile(filename: string, mode: ModeStr = "exec") {
 export function runParserFromFile(filename: string, mode: ModeStr = "exec") {
     return parserFromFile(filename, mode).parse();
 }
+
+export var astFromString = runParserFromString;
+export var astFromFile = runParserFromFile;

--- a/src/parser/verbose_parser.ts
+++ b/src/parser/verbose_parser.ts
@@ -23,7 +23,7 @@ const log = (s: string, col: colors) => {
         console.log(Colors[col](`${s.replace(/\n/g, "\\n")}`));
     }
 };
-const argstr = (arg?: string) => (arg === undefined ? "" : `'${arg}'`);
+const argstr = (arg?: string | number) => (arg === undefined ? "" : `'${tokens[arg as number] || arg}'`);
 
 /** For non-memoized functions that we want to be logged.*/
 export function logger(_target: VerboseParser, propertyKey: string, descriptor: PropertyDescriptor) {
@@ -149,7 +149,7 @@ export class VerboseParser extends BaseParser {
     constructor(tokenizer: Tokenizer) {
         super(tokenizer);
         this._level = 0;
-        this.rewrap(["name", "string", "number", "op", "expect"]);
+        this.rewrap(["name", "string", "number", "keyword", "expect"]);
     }
     showpeek(): string {
         const tok = this.peek();

--- a/src/symtable/mod.ts
+++ b/src/symtable/mod.ts
@@ -3,6 +3,8 @@
 
 import type { Module, Expression, Interactive, mod } from "../ast/astnodes.ts";
 import { ASTKind } from "../ast/astnodes.ts";
+import { astFromFile, astFromString } from "../parser/mod.ts";
+import type { ModeStr } from "../parser/mod.ts";
 import { SymbolTable } from "./SymbolTable.ts";
 import { BlockType } from "./util.ts";
 
@@ -37,4 +39,14 @@ export function buildSymbolTable(mod: mod, filename = "<string>", future: any = 
     st.analyze();
 
     return st;
+}
+
+export function symtableFromString(source: string, mode: ModeStr = "exec", filename = "<string>"): SymbolTable {
+    const ast = astFromString(source, mode, filename);
+    return buildSymbolTable(ast, filename);
+}
+
+export function symtableFromFile(filename: string, mode: ModeStr = "exec"): SymbolTable {
+    const ast = astFromFile(filename, mode);
+    return buildSymbolTable(ast, filename);
 }

--- a/src/tokenize/token.ts
+++ b/src/tokenize/token.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 the Skulpt Project
 // SPDX-License-Identifier: MIT
 
-export const enum tokens {
+export enum tokens {
     ENDMARKER,
     NAME,
     NUMBER,

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -2,7 +2,7 @@ import { dump } from "../support/ast_dump.ts";
 import { getPyAstDump } from "../support/py_ast_dump.ts";
 // replace with assertEquals when string comparison is better.
 import { assertEqualsString } from "../support/diff.ts";
-import { runParserFromString } from "../src/parser/parse.ts";
+import { runParserFromString } from "../src/parser/mod.ts";
 import { runTests } from "./run_tests_helper.ts";
 
 // deno-lint-ignore camelcase

--- a/tools/gen_asdl/asdl_js.py
+++ b/tools/gen_asdl/asdl_js.py
@@ -220,10 +220,10 @@ class PrototypeVisitor(EmitVisitor):
         ts_args = []
         for atype, aname, opt, seq in args:
             atype = atype
-            if opt or seq:
+            if (opt or seq) and not attrs:
                 # optional types really means can be null rather than optional
                 atype = atype if not opt and not seq else atype + " | null"
-            ts_args.append(f"{aname}{'?' if opt and attrs else ''}: {atype}")
+            ts_args.append(f"{aname}: {atype}")
         return ", ".join(ts_args)
 
     def visitConstructor(self, cons, type, attrs):
@@ -248,10 +248,10 @@ class FunctionVisitor(PrototypeVisitor):
     def emit_instance_types(self, args, attrs=False):
         for atype, aname, opt, seq in args:
             atype = atype
-            if opt:
+            if opt and not attrs:
                 # optional types really means can be null rather than optional
                 atype = atype if not opt else atype + " | null"
-            self.emit(f"{aname}{'?' if opt and attrs else ''}: {atype};", 1)
+            self.emit(f"{aname}: {atype};", 1)
 
     def emit_function(self, name, ts_type, args, attrs, union=1):
         emit = self.emit
@@ -414,7 +414,7 @@ AST.prototype._attributes = [];
 AST.prototype._fields = [];
 AST.prototype._enum = false;
 
-export type Attrs = [number, number, number | null | undefined, number | null | undefined];
+export type Attrs = [number, number, number, number];
 const _attrs = ["lineno", "col_offset", "end_lineno", "end_col_offset"];
 
 """


### PR DESCRIPTION
make `end_lineno` and `end_col_offset` compulsory for our astnodes.

Create some helper functions for symtable.
move `parser/parse.ts` to `parse/mod.ts` for consistency.