### PR TITLE
port over fix to number as float

### DIFF
--- a/src/parser/parse_number.ts
+++ b/src/parser/parse_number.ts
@@ -7,7 +7,7 @@ declare global {
     var JSBI: { BigInt: typeof BigInt };
 }
 
-const FLOAT_RE = new RegExp(Floatnumber);
+const FLOAT_RE = new RegExp("^" + Floatnumber + "$");
 
 /**
  * convert string to complex, float or int.


### PR DESCRIPTION
basically we fail for numbers that have a partial match to the float test e.g.

`0x1234e455`

will get converted to a float but should be an int